### PR TITLE
Implement lobby screen with player list and ready state

### DIFF
--- a/src/components/room/PlayerItem.tsx
+++ b/src/components/room/PlayerItem.tsx
@@ -1,0 +1,29 @@
+import type { Player } from "@/types/room"
+import { useTranslation } from "react-i18next"
+import { Item, ItemContent, ItemTitle } from "../ui/item"
+import { Badge } from "../ui/badge"
+
+interface PlayerItemProps {
+  player: Player
+  isMe: boolean
+}
+
+export default function PlayerItem({ player, isMe }: PlayerItemProps) {
+  const { t } = useTranslation("room")
+
+  return (
+    <Item variant={`${isMe ? "muted" : "outline"}`} className="w-auto">
+      <ItemContent>
+        <ItemTitle>
+          {player.id}
+          {isMe && <Badge variant="outline">{t("you")}</Badge>}
+        </ItemTitle>
+      </ItemContent>
+      <ItemContent>
+        <Badge variant={`${player.ready ? "default" : "destructive"}`}>
+          {t(player.ready ? "player.ready" : "player.notReady")}
+        </Badge>
+      </ItemContent>
+    </Item>
+  )
+}

--- a/src/components/room/PlayerList.tsx
+++ b/src/components/room/PlayerList.tsx
@@ -1,0 +1,17 @@
+import type { Player } from "@/types/room"
+import PlayerItem from "./PlayerItem"
+
+interface PlayerListProps {
+  players: Player[]
+  myId: string
+}
+
+export default function PlayerList({ players, myId }: PlayerListProps) {
+  return (
+    <div className="flex h-full w-auto flex-col justify-center gap-1">
+      {players.map((player) => (
+        <PlayerItem player={player} isMe={player.id === myId} />
+      ))}
+    </div>
+  )
+}

--- a/src/components/room/ReadyButton.tsx
+++ b/src/components/room/ReadyButton.tsx
@@ -1,0 +1,18 @@
+import { useReadyState } from "@/hooks/room/useReadyState"
+import { Button } from "@/components/ui/button"
+import { useTranslation } from "react-i18next"
+
+interface ReadyButtonProps {
+  send: (data: object) => void
+}
+
+export default function ReadyButton({ send }: ReadyButtonProps) {
+  const { t } = useTranslation("room")
+  const { ready, toggle } = useReadyState(send)
+
+  return (
+    <Button onClick={toggle} variant={ready ? "secondary" : "default"}>
+      {ready ? t("player.notReady") : t("player.ready")}
+    </Button>
+  )
+}

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,52 @@
+import { mergeProps } from "@base-ui/react/merge-props"
+import { useRender } from "@base-ui/react/use-render"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const badgeVariants = cva(
+  "group/badge inline-flex h-5 w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-3xl border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-all focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3!",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
+        secondary:
+          "bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80",
+        destructive:
+          "bg-destructive/10 text-destructive focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:focus-visible:ring-destructive/40 [a]:hover:bg-destructive/20",
+        outline:
+          "border-border text-foreground [a]:hover:bg-muted [a]:hover:text-muted-foreground",
+        ghost:
+          "hover:bg-muted hover:text-muted-foreground dark:hover:bg-muted/50",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function Badge({
+  className,
+  variant = "default",
+  render,
+  ...props
+}: useRender.ComponentProps<"span"> & VariantProps<typeof badgeVariants>) {
+  return useRender({
+    defaultTagName: "span",
+    props: mergeProps<"span">(
+      {
+        className: cn(badgeVariants({ variant }), className),
+      },
+      props
+    ),
+    render,
+    state: {
+      slot: "badge",
+      variant,
+    },
+  })
+}
+
+export { Badge, badgeVariants }

--- a/src/components/ui/item.tsx
+++ b/src/components/ui/item.tsx
@@ -1,0 +1,201 @@
+import * as React from "react"
+import { mergeProps } from "@base-ui/react/merge-props"
+import { useRender } from "@base-ui/react/use-render"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+import { Separator } from "@/components/ui/separator"
+
+function ItemGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      role="list"
+      data-slot="item-group"
+      className={cn(
+        "group/item-group flex w-full flex-col gap-4 has-data-[size=sm]:gap-2.5 has-data-[size=xs]:gap-2",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function ItemSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof Separator>) {
+  return (
+    <Separator
+      data-slot="item-separator"
+      orientation="horizontal"
+      className={cn("my-2", className)}
+      {...props}
+    />
+  )
+}
+
+const itemVariants = cva(
+  "group/item flex w-full flex-wrap items-center rounded-2xl border text-sm transition-colors duration-100 outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 [a]:transition-colors [a]:hover:bg-muted",
+  {
+    variants: {
+      variant: {
+        default: "border-transparent",
+        outline: "border-border",
+        muted: "border-transparent bg-muted/50",
+      },
+      size: {
+        default: "gap-3.5 px-4 py-3.5",
+        sm: "gap-3.5 px-3.5 py-3",
+        xs: "gap-2.5 px-3 py-2.5 in-data-[slot=dropdown-menu-content]:p-0",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+function Item({
+  className,
+  variant = "default",
+  size = "default",
+  render,
+  ...props
+}: useRender.ComponentProps<"div"> & VariantProps<typeof itemVariants>) {
+  return useRender({
+    defaultTagName: "div",
+    props: mergeProps<"div">(
+      {
+        className: cn(itemVariants({ variant, size, className })),
+      },
+      props
+    ),
+    render,
+    state: {
+      slot: "item",
+      variant,
+      size,
+    },
+  })
+}
+
+const itemMediaVariants = cva(
+  "flex shrink-0 items-center justify-center gap-2 group-has-data-[slot=item-description]/item:translate-y-0.5 group-has-data-[slot=item-description]/item:self-start [&_svg]:pointer-events-none",
+  {
+    variants: {
+      variant: {
+        default: "bg-transparent",
+        icon: "[&_svg:not([class*='size-'])]:size-4",
+        image:
+          "size-10 overflow-hidden rounded-xl group-data-[size=sm]/item:size-8 group-data-[size=xs]/item:size-6 group-data-[size=xs]/item:rounded-lg [&_img]:size-full [&_img]:object-cover",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function ItemMedia({
+  className,
+  variant = "default",
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof itemMediaVariants>) {
+  return (
+    <div
+      data-slot="item-media"
+      data-variant={variant}
+      className={cn(itemMediaVariants({ variant, className }))}
+      {...props}
+    />
+  )
+}
+
+function ItemContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="item-content"
+      className={cn(
+        "flex flex-1 flex-col gap-1 group-data-[size=xs]/item:gap-0.5 [&+[data-slot=item-content]]:flex-none",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function ItemTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="item-title"
+      className={cn(
+        "font-heading line-clamp-1 flex w-fit items-center gap-2 text-sm leading-snug font-medium underline-offset-4",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function ItemDescription({ className, ...props }: React.ComponentProps<"p">) {
+  return (
+    <p
+      data-slot="item-description"
+      className={cn(
+        "line-clamp-2 text-left text-sm font-normal text-muted-foreground [&>a]:underline [&>a]:underline-offset-4 [&>a:hover]:text-primary",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function ItemActions({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="item-actions"
+      className={cn("flex items-center gap-2", className)}
+      {...props}
+    />
+  )
+}
+
+function ItemHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="item-header"
+      className={cn(
+        "flex basis-full items-center justify-between gap-2",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function ItemFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="item-footer"
+      className={cn(
+        "flex basis-full items-center justify-between gap-2",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Item,
+  ItemMedia,
+  ItemContent,
+  ItemActions,
+  ItemGroup,
+  ItemSeparator,
+  ItemTitle,
+  ItemDescription,
+  ItemHeader,
+  ItemFooter,
+}

--- a/src/hooks/room/useReadyState.ts
+++ b/src/hooks/room/useReadyState.ts
@@ -1,0 +1,13 @@
+import { useState } from "react"
+
+export function useReadyState(send: (data: object) => void) {
+  const [ready, setReady] = useState(false)
+
+  const toggle = () => {
+    const next = !ready
+    setReady(next)
+    send({ type: next ? "READY" : "UNREADY" })
+  }
+
+  return { ready, toggle }
+}


### PR DESCRIPTION
Implements the lobby screen, completing the last acceptance criterion for the room joining story. Players in the room can now see who has joined and toggle their ready state; when all players are ready the server broadcasts `GAME_START`.

## Changes

- Created `useReadyState` hook to track local ready state and send `READY`/`UNREADY` messages to PartyKit on toggle
- Created `ReadyButton` component that toggles between ready/not-ready and reflects state via button variant
- Created `PlayerItem` component showing a player's ID, a "You" badge for the local player, and a ready/not-ready status badge
- Created `PlayerList` component that renders a `PlayerItem` for each connected player
- Added `Badge` UI primitive with `default`, `secondary`, `destructive`, `outline`, `ghost`, and `link` variants
- Added `Item` UI primitive family (`Item`, `ItemContent`, `ItemTitle`, `ItemMedia`, `ItemActions`, `ItemHeader`, `ItemFooter`, `ItemGroup`, `ItemSeparator`) used to lay out each player row

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **PlayerItem**: Display player ID, local player indicator badge, and ready state badge
- **PlayerList**: Render collection of PlayerItem components for connected players
- **ReadyButton**: Toggle button for ready state with dynamic label and variant
- **Badge**: UI primitive with `default`, `secondary`, `destructive`, `outline`, `ghost`, and `link` variants
- **Item (and related)**: UI primitive family (`Item`, `ItemContent`, `ItemTitle`, `ItemMedia`, `ItemActions`, `ItemHeader`, `ItemFooter`, `ItemGroup`, `ItemSeparator`) for player row layout
- **useReadyState**: Hook to manage local ready state and dispatch `READY`/`UNREADY` messages via send callback

<!-- end of auto-generated comment: release notes by coderabbit.ai -->