### PR TITLE
Feature/4/game board

### DIFF
--- a/src/components/game/Board.tsx
+++ b/src/components/game/Board.tsx
@@ -1,0 +1,18 @@
+import { BOARD_SIZE } from "@/lib/board"
+import Cell from "@/components/game/Cell"
+
+export default function Board() {
+  return (
+    <div
+      className="grid aspect-square gap-1 overflow-hidden"
+      style={{
+        gridTemplateColumns: `repeat(${BOARD_SIZE}, 1fr)`,
+        height: "min(100cqw, 100cqh)",
+      }}
+    >
+      {Array.from({ length: BOARD_SIZE * BOARD_SIZE }).map((_, i) => (
+        <Cell key={i} />
+      ))}
+    </div>
+  )
+}

--- a/src/components/game/Board.tsx
+++ b/src/components/game/Board.tsx
@@ -1,4 +1,9 @@
-import { BOARD_SIZE, getCellType } from "@/lib/board"
+import {
+  BOARD_SIZE,
+  getCellType,
+  CELL_VARIANTS,
+  CELL_LABELS,
+} from "@/lib/board"
 import Cell from "@/components/game/Cell"
 
 export default function Board() {
@@ -13,7 +18,14 @@ export default function Board() {
       {Array.from({ length: BOARD_SIZE * BOARD_SIZE }).map((_, i) => {
         const row = Math.floor(i / BOARD_SIZE)
         const col = i % BOARD_SIZE
-        return <Cell key={i} type={getCellType(row, col)} />
+        const type = getCellType(row, col)
+        return (
+          <Cell
+            key={i}
+            variant={CELL_VARIANTS[type]}
+            label={CELL_LABELS[type]}
+          />
+        )
       })}
     </div>
   )

--- a/src/components/game/Board.tsx
+++ b/src/components/game/Board.tsx
@@ -1,4 +1,4 @@
-import { BOARD_SIZE } from "@/lib/board"
+import { BOARD_SIZE, getCellType } from "@/lib/board"
 import Cell from "@/components/game/Cell"
 
 export default function Board() {
@@ -10,9 +10,11 @@ export default function Board() {
         height: "min(100cqw, 100cqh)",
       }}
     >
-      {Array.from({ length: BOARD_SIZE * BOARD_SIZE }).map((_, i) => (
-        <Cell key={i} />
-      ))}
+      {Array.from({ length: BOARD_SIZE * BOARD_SIZE }).map((_, i) => {
+        const row = Math.floor(i / BOARD_SIZE)
+        const col = i % BOARD_SIZE
+        return <Cell key={i} type={getCellType(row, col)} />
+      })}
     </div>
   )
 }

--- a/src/components/game/Cell.tsx
+++ b/src/components/game/Cell.tsx
@@ -1,3 +1,22 @@
-export default function Cell() {
-  return <div className="aspect-square rounded-xl bg-accent" />
+import type { CellType } from "@/lib/board"
+
+const variants: Record<CellType, string> = {
+  normal: "bg-accent",
+  doubleLetter: "bg-chart-1",
+  tripleLetter: "bg-chart-2",
+  doubleWord: "bg-chart-4",
+  tripleWord: "bg-chart-5",
+  center: "bg-foreground",
+}
+
+interface CellProps {
+  type: CellType
+}
+
+export default function Cell({ type = "normal" }: CellProps) {
+  return (
+    <div
+      className={`aspect-square rounded-[25%] bg-accent ${variants[type]}`}
+    />
+  )
 }

--- a/src/components/game/Cell.tsx
+++ b/src/components/game/Cell.tsx
@@ -1,0 +1,3 @@
+export default function Cell() {
+  return <div className="aspect-square rounded-xl bg-accent" />
+}

--- a/src/components/game/Cell.tsx
+++ b/src/components/game/Cell.tsx
@@ -1,22 +1,16 @@
-import type { CellType } from "@/lib/board"
-
-const variants: Record<CellType, string> = {
-  normal: "bg-accent",
-  doubleLetter: "bg-chart-1",
-  tripleLetter: "bg-chart-2",
-  doubleWord: "bg-chart-4",
-  tripleWord: "bg-chart-5",
-  center: "bg-foreground",
-}
-
 interface CellProps {
-  type: CellType
+  variant: string
+  label?: string
 }
 
-export default function Cell({ type = "normal" }: CellProps) {
+export default function Cell({ variant, label }: CellProps) {
   return (
     <div
-      className={`aspect-square rounded-[25%] bg-accent ${variants[type]}`}
-    />
+      className={`flex aspect-square items-center justify-center rounded-[25%] ${variant}`}
+    >
+      <span className="text-[clamp(0.6rem,1.5cqw,1.5rem)] font-bold text-accent">
+        {label}
+      </span>
+    </div>
   )
 }

--- a/src/lib/board.ts
+++ b/src/lib/board.ts
@@ -1,0 +1,1 @@
+export const BOARD_SIZE = 15

--- a/src/lib/board.ts
+++ b/src/lib/board.ts
@@ -83,3 +83,21 @@ export const CELL_TYPES: Record<number, CellType> = {
 export function getCellType(row: number, col: number): CellType {
   return CELL_TYPES[row * BOARD_SIZE + col] ?? "normal"
 }
+
+export const CELL_VARIANTS: Record<CellType, string> = {
+  normal: "bg-accent",
+  doubleLetter: "bg-[var(--chart-1)]",
+  tripleLetter: "bg-[var(--chart-2)]",
+  doubleWord: "bg-[var(--chart-4)]",
+  tripleWord: "bg-[var(--chart-5)]",
+  center: "bg-foreground",
+}
+
+export const CELL_LABELS: Record<CellType, string> = {
+  normal: "",
+  doubleLetter: "DL",
+  tripleLetter: "TL",
+  doubleWord: "DW",
+  tripleWord: "TW",
+  center: "★",
+}

--- a/src/lib/board.ts
+++ b/src/lib/board.ts
@@ -1,1 +1,85 @@
 export const BOARD_SIZE = 15
+
+export type CellType =
+  | "normal"
+  | "doubleLetter"
+  | "tripleLetter"
+  | "doubleWord"
+  | "tripleWord"
+  | "center"
+
+export const CELL_TYPES: Record<number, CellType> = {
+  // Triple word
+  0: "tripleWord",
+  7: "tripleWord",
+  14: "tripleWord",
+  105: "tripleWord",
+  119: "tripleWord",
+  210: "tripleWord",
+  217: "tripleWord",
+  224: "tripleWord",
+
+  // Double word
+  16: "doubleWord",
+  28: "doubleWord",
+  32: "doubleWord",
+  42: "doubleWord",
+  48: "doubleWord",
+  56: "doubleWord",
+  64: "doubleWord",
+  70: "doubleWord",
+  154: "doubleWord",
+  160: "doubleWord",
+  168: "doubleWord",
+  176: "doubleWord",
+  182: "doubleWord",
+  192: "doubleWord",
+  196: "doubleWord",
+  208: "doubleWord",
+
+  // Triple letter
+  20: "tripleLetter",
+  24: "tripleLetter",
+  76: "tripleLetter",
+  80: "tripleLetter",
+  84: "tripleLetter",
+  88: "tripleLetter",
+  136: "tripleLetter",
+  140: "tripleLetter",
+  144: "tripleLetter",
+  148: "tripleLetter",
+  200: "tripleLetter",
+  204: "tripleLetter",
+
+  // Double letter
+  3: "doubleLetter",
+  11: "doubleLetter",
+  36: "doubleLetter",
+  38: "doubleLetter",
+  45: "doubleLetter",
+  52: "doubleLetter",
+  59: "doubleLetter",
+  92: "doubleLetter",
+  96: "doubleLetter",
+  98: "doubleLetter",
+  102: "doubleLetter",
+  108: "doubleLetter",
+  116: "doubleLetter",
+  126: "doubleLetter",
+  128: "doubleLetter",
+  132: "doubleLetter",
+  165: "doubleLetter",
+  172: "doubleLetter",
+  179: "doubleLetter",
+  186: "doubleLetter",
+  188: "doubleLetter",
+  213: "doubleLetter",
+  221: "doubleLetter",
+
+  // Center
+  112: "center",
+}
+
+export function getCellType(row: number, col: number): CellType {
+  return CELL_TYPES[row * BOARD_SIZE + col] ?? "normal"
+}

--- a/src/locales/en/board.json
+++ b/src/locales/en/board.json
@@ -1,0 +1,9 @@
+{
+  "cellLabels": {
+    "doubleLetter": "DL",
+    "tripleLetter": "TL",
+    "doubleWord": "DW",
+    "tripleWord": "TW",
+    "center": "★"
+  }
+}

--- a/src/locales/index.ts
+++ b/src/locales/index.ts
@@ -1,4 +1,5 @@
 import room from "@/locales/en/room.json"
 import common from "@/locales/en/common.json"
+import board from "@/locales/en/board.json"
 
-export default { room, common }
+export default { room, common, board }

--- a/src/pages/Game.tsx
+++ b/src/pages/Game.tsx
@@ -1,0 +1,9 @@
+import Board from "@/components/game/Board"
+
+export default function Game() {
+  return (
+    <div className="@container-[size] flex h-full w-full flex-col items-center justify-center gap-1">
+      <Board />
+    </div>
+  )
+}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,3 +1,4 @@
+import Game from "@/pages/Game"
 import Home from "@/pages/Home"
 import NotFound from "@/pages/NotFound"
 import Room from "@/pages/Room"
@@ -7,4 +8,5 @@ export const router = createBrowserRouter([
   { path: "/", element: <Home /> },
   { path: "*", element: <NotFound /> },
   { path: "/room/:roomId", element: <Room /> },
+  { path: "/game/:roomId", element: <Game /> },
 ])


### PR DESCRIPTION
Implements the game board UI, rendering a 15×15 Scrabble grid with visually distinct premium
squares and responsive cell labels. Cell types and their display mappings (variants, labels)
are defined in `lib/board.ts` as the single source of truth. `Cell` is a dumb component that
receives only `variant` and `label` as props, keeping all board logic in `Board` and `lib/board.ts`.
The game is accessible at `/game/:roomId`.

## Changes

- Created `lib/board.ts` with `CELL_TYPES` map, `getCellType`, `CELL_VARIANTS`, and `CELL_LABELS`
- Created `Board` component that resolves cell type to variant and label before passing to `Cell`
- Created `Cell` as a dumb component accepting `variant` and `label` props with responsive label sizing via `clamp()`
- Created `Game` page wrapping `Board` in a container query context
- Added `/game/:roomId` route pointing to `Game` page
- Added `board.json` locale file with cell labels (placeholder `"???"` for center — needs resolution)
- Added `board` locale to `locales/index.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **src/lib/board.ts**: Added Scrabble board configuration (15×15 grid) with cell type definitions, premium square mappings, variant-to-CSS-class lookups, and cell label mappings
- **src/components/game/Cell.tsx**: Added dumb Cell component that accepts variant (CSS class) and label (display text) props and renders a square cell with responsive label sizing
- **src/components/game/Board.tsx**: Added Board component that generates 15×15 grid, resolves cell types to variants/labels via lib/board.ts, and renders Cell components
- **src/pages/Game.tsx**: Added Game page wrapper providing container query context for Board
- **src/locales/en/board.json**: Added board locale file with cell label translations (DL, TL, DW, TW, ★)
- **src/locales/index.ts**: Registered board locale module as singleton source of truth
- **src/routes/index.tsx**: Added route `/game/:roomId` pointing to Game page

<!-- end of auto-generated comment: release notes by coderabbit.ai -->