### PR TITLE
Use custom useTheme hook instead of next-themes

### DIFF
--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -1,6 +1,12 @@
-import { useTheme } from "next-themes"
+import { useTheme } from "../theme-provider"
 import { Toaster as Sonner, type ToasterProps } from "sonner"
-import { CircleCheckIcon, InfoIcon, TriangleAlertIcon, OctagonXIcon, Loader2Icon } from "lucide-react"
+import {
+  CircleCheckIcon,
+  InfoIcon,
+  TriangleAlertIcon,
+  OctagonXIcon,
+  Loader2Icon,
+} from "lucide-react"
 
 const Toaster = ({ ...props }: ToasterProps) => {
   const { theme = "system" } = useTheme()
@@ -10,21 +16,11 @@ const Toaster = ({ ...props }: ToasterProps) => {
       theme={theme as ToasterProps["theme"]}
       className="toaster group"
       icons={{
-        success: (
-          <CircleCheckIcon className="size-4" />
-        ),
-        info: (
-          <InfoIcon className="size-4" />
-        ),
-        warning: (
-          <TriangleAlertIcon className="size-4" />
-        ),
-        error: (
-          <OctagonXIcon className="size-4" />
-        ),
-        loading: (
-          <Loader2Icon className="size-4 animate-spin" />
-        ),
+        success: <CircleCheckIcon className="size-4" />,
+        info: <InfoIcon className="size-4" />,
+        warning: <TriangleAlertIcon className="size-4" />,
+        error: <OctagonXIcon className="size-4" />,
+        loading: <Loader2Icon className="size-4 animate-spin" />,
       }}
       style={
         {


### PR DESCRIPTION
Sonner toasts were not reflecting the app's active theme because `sonner.tsx` imported `useTheme` from `next-themes`, which has no provider in the component tree. This meant `useTheme()` always returned its default value, causing toasts to render in the default theme regardless of what the user had selected. This PR fixes the import to use the app's custom `ThemeProvider` hook instead.

## Changes

- Fixed `sonner.tsx` to import `useTheme` from `../theme-provider` instead of `next-themes`
- Reformatted lucide-react named imports to one-per-line for readability
- Collapsed single-element JSX in the `icons` prop to inline expressions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **Toaster component** (src/components/ui/sonner.tsx): Fix theme not being applied to Sonner toasts by replacing `useTheme` import from next-themes with custom theme-provider hook; reformat lucide-react named imports to one-per-line; collapse single-element JSX icon assignments to inline expressions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->