### PR TITLE
fix(roomId): derive generateRoomId length from ROOM_CODE_LENGTH

### DIFF
--- a/src/lib/roomId.ts
+++ b/src/lib/roomId.ts
@@ -1,5 +1,8 @@
 export const ROOM_CODE_LENGTH = 6
 
 export function generateRoomId() {
-  return Math.random().toString(36).substring(2, 8).toUpperCase()
+  return Math.random()
+    .toString(36)
+    .substring(2, 2 + ROOM_CODE_LENGTH)
+    .toUpperCase()
 }


### PR DESCRIPTION
`generateRoomId` was using a hardcoded `substring(2, 8)` to produce 6-character room codes, silently ignoring `ROOM_CODE_LENGTH`. If the constant were updated, generated IDs would continue to be 6 characters while the join validator enforced the new length, causing valid codes to be rejected with no obvious cause. This PR fixes the end index to `2 + ROOM_CODE_LENGTH` so generation and validation stay in sync automatically.

## Changes

- Fixed `generateRoomId` in `roomId.ts` to derive the `substring` end index from `ROOM_CODE_LENGTH` instead of hardcoding `8`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **`generateRoomId()` in `src/lib/roomId.ts`**: Updated substring bounds from hardcoded `substring(2, 8)` to `substring(2, 2 + ROOM_CODE_LENGTH)` to derive room code length from the `ROOM_CODE_LENGTH` constant, ensuring generation and validation remain synchronized

<!-- end of auto-generated comment: release notes by coderabbit.ai -->