### PR TITLE
Bump compatibility date for partykit

### DIFF
--- a/partykit.json
+++ b/partykit.json
@@ -2,5 +2,5 @@
   "$schema": "https://www.partykit.io/schema.json",
   "name": "mova-party",
   "main": "party/index.ts",
-  "compatibilityDate": "2024-01-01"
+  "compatibilityDate": "2026-04-04"
 }


### PR DESCRIPTION
Bumps the PartyKit compatibility date from `2024-01-01` to `2026-04-04` in `partykit.json`. This ensures the project targets a more recent Workers runtime snapshot, picking up any bug fixes and API updates released since the previous date.

## Changes

- Updated `compatibilityDate` in `partykit.json` from `2024-01-01` to `2026-04-04`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **partykit.json**: Updated `compatibilityDate` from `2024-01-01` to `2026-04-04`
  - Intent: Target more recent Workers runtime snapshot to pick up bug fixes and API updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->