### PR TITLE
Add stable React keys to PlayerList items

### DIFF
--- a/src/components/room/PlayerList.tsx
+++ b/src/components/room/PlayerList.tsx
@@ -9,9 +9,11 @@ interface PlayerListProps {
 export default function PlayerList({ players, myId }: PlayerListProps) {
   return (
     <div className="flex h-full w-auto flex-col justify-center gap-1">
-      {players.map((player) => (
-        <PlayerItem player={player} isMe={player.id === myId} />
-      ))}
+      {players.map((player) => {
+        const isMe = player.id === myId
+
+        return <PlayerItem key={player.id} player={player} isMe={isMe} />
+      })}
     </div>
   )
 }


### PR DESCRIPTION
Fixes a missing `key` prop warning in `PlayerList` by adding `key={player.id}` to each rendered `PlayerItem`. Also extracts the `isMe` boolean into a local variable for minor readability improvement.

## Changes

- Added `key={player.id}` to `PlayerItem` in `PlayerList.tsx` to resolve React's missing key warning
- Extracted `isMe` into a local variable inside the `.map()` callback for clarity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changed Components

- **PlayerList.tsx**
  - Added `key={player.id}` prop to `PlayerItem` elements to resolve React missing key warning and ensure proper list reconciliation
  - Refactored `.map()` callback from implicit return to block body
  - Extracted `isMe` boolean computation into local variable for improved readability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->