### PR TITLE
Refactor translation schema and improve socket error handling

### DIFF
--- a/src/components/room/CreateRoomButton.tsx
+++ b/src/components/room/CreateRoomButton.tsx
@@ -6,5 +6,5 @@ export default function CreateRoomButton() {
   const { t } = useTranslation("room")
   const createRoom = useCreateRoom()
 
-  return <Button onClick={createRoom}>{t("createRoom")}</Button>
+  return <Button onClick={createRoom}>{t("actions.createRoom")}</Button>
 }

--- a/src/components/room/JoinRoomInput.tsx
+++ b/src/components/room/JoinRoomInput.tsx
@@ -44,7 +44,7 @@ export default function JoinRoomInput() {
         variant="secondary"
         onClick={handleJoin}
       >
-        {t("joinRoom")}
+        {t("actions.joinRoom")}
       </Button>
     </div>
   )

--- a/src/components/room/LeaveRoomButton.tsx
+++ b/src/components/room/LeaveRoomButton.tsx
@@ -24,19 +24,19 @@ export default function LeaveRoomButton() {
   return (
     <AlertDialog>
       <AlertDialogTrigger
-        render={<Button variant="destructive">{t("leaveRoom")}</Button>}
+        render={<Button variant="destructive">{t("actions.leaveRoom")}</Button>}
       />
       <AlertDialogContent>
         <AlertDialogHeader>
-          <AlertDialogTitle>{t("leaveRoomDialog.title")}</AlertDialogTitle>
+          <AlertDialogTitle>{t("dialogs.leaveRoom.title")}</AlertDialogTitle>
           <AlertDialogDescription>
-            {t("leaveRoomDialog.description")}
+            {t("dialogs.leaveRoom.description")}
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>
-          <AlertDialogCancel>{t("leaveRoomDialog.cancel")}</AlertDialogCancel>
+          <AlertDialogCancel>{t("dialogs.leaveRoom.cancel")}</AlertDialogCancel>
           <AlertDialogAction onClick={handleLeave}>
-            {t("leaveRoomDialog.confirm")}
+            {t("dialogs.leaveRoom.confirm")}
           </AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>

--- a/src/components/room/PlayerItem.tsx
+++ b/src/components/room/PlayerItem.tsx
@@ -16,11 +16,11 @@ export default function PlayerItem({ player, isMe }: PlayerItemProps) {
       <ItemContent>
         <ItemTitle>
           {player.id}
-          {isMe && <Badge variant="outline">{t("you")}</Badge>}
+          {isMe && <Badge variant="outline">{t("labels.you")}</Badge>}
         </ItemTitle>
       </ItemContent>
       <ItemContent>
-        <Badge variant={`${player.ready ? "default" : "destructive"}`}>
+        <Badge variant={`${player.ready ? "default" : "secondary"}`}>
           {t(player.ready ? "player.ready" : "player.notReady")}
         </Badge>
       </ItemContent>

--- a/src/components/room/RoomIdDisplay.tsx
+++ b/src/components/room/RoomIdDisplay.tsx
@@ -19,7 +19,7 @@ export default function RoomIdDisplay({ roomId }: RoomIdDisplayProps) {
     <div className="flex gap-1">
       <Input readOnly value={roomId} className="field-sizing-content" />
       <Button variant="secondary" onClick={handleCopy}>
-        {t("copyRoomLink")}
+        {t("actions.copyRoomLink")}
       </Button>
     </div>
   )

--- a/src/hooks/room/useCopyRoomLink.ts
+++ b/src/hooks/room/useCopyRoomLink.ts
@@ -8,12 +8,12 @@ export const useCopyRoomLink = () => {
     const url = `${window.location.origin}/room/${roomId}`
     try {
       navigator.clipboard.writeText(url)
-      toast.success(t("success.title"), {
-        description: t("success.description"),
+      toast.success(t("status.success.copyRoomLink.title"), {
+        description: t("status.success.copyRoomLink.description"),
       })
     } catch {
-      toast.error(t("error.title"), {
-        description: t("error.description"),
+      toast.error(t("errors.clipboard.copyRoomLink.title"), {
+        description: t("errors.clipboard.copyRoomLink.description"),
       })
     }
   }

--- a/src/hooks/room/useRoomSession.ts
+++ b/src/hooks/room/useRoomSession.ts
@@ -23,8 +23,8 @@ export function useRoomSession(roomId: string) {
             break
           case "ROOM_FULL":
             socket.close()
-            toast.error(t("roomFull.title"), {
-              description: t("roomFull.description"),
+            toast.error(t("events.roomFull.title"), {
+              description: t("events.roomFull.description"),
             })
             navigate("/")
             break
@@ -38,6 +38,17 @@ export function useRoomSession(roomId: string) {
       } catch {
         console.log("non-JSON message:", event.data)
       }
+    },
+    onError() {
+      toast.error(t("errors.connection.failed.title"), {
+        description: t("errors.connection.failed.description"),
+      })
+      navigate("/")
+    },
+    onClose() {
+      toast.error(t("errors.connection.lost.title"), {
+        description: t("errors.connection.lost.description"),
+      })
     },
   })
 

--- a/src/hooks/room/useRoomSession.ts
+++ b/src/hooks/room/useRoomSession.ts
@@ -1,7 +1,7 @@
 import { toast } from "sonner"
 import { useTranslation } from "react-i18next"
 import { useNavigate } from "react-router"
-import { useState } from "react"
+import { useRef, useState } from "react"
 import type { Player, ServerMessage } from "@/types/room"
 import usePartySocket from "partysocket/react"
 
@@ -10,6 +10,7 @@ export function useRoomSession(roomId: string) {
   const navigate = useNavigate()
   const [players, setPlayers] = useState<Player[]>([])
   const [myId, setMyId] = useState<string | null>(null)
+  const intentionalClose = useRef(false)
 
   const socket = usePartySocket({
     host: import.meta.env.VITE_PARTYKIT_HOST ?? "localhost:1999",
@@ -22,6 +23,7 @@ export function useRoomSession(roomId: string) {
             setMyId(msg.myId)
             break
           case "ROOM_FULL":
+            intentionalClose.current = true
             socket.close()
             toast.error(t("events.roomFull.title"), {
               description: t("events.roomFull.description"),
@@ -46,9 +48,11 @@ export function useRoomSession(roomId: string) {
       navigate("/")
     },
     onClose() {
+      if (intentionalClose.current) return
       toast.error(t("errors.connection.lost.title"), {
         description: t("errors.connection.lost.description"),
       })
+      navigate("/")
     },
   })
 

--- a/src/locales/en/room.json
+++ b/src/locales/en/room.json
@@ -1,30 +1,55 @@
 {
-  "createRoom": "Create Room",
-  "copyRoomLink": "Copy Link",
-  "success": {
-    "title": "Link copied!",
-    "description": "Share it with your friend"
+  "actions": {
+    "createRoom": "Create Room",
+    "joinRoom": "Join Room",
+    "leaveRoom": "Leave Room",
+    "copyRoomLink": "Copy Link"
   },
-  "error": {
-    "title": "Could not copy link",
-    "description": "Share it manually with your friend"
-  },
-  "copyRoomLinkError": "Could not copy link, share it manually",
-  "joinRoom": "Join Room",
-  "roomFull": {
-    "title": "Room is full",
-    "description": "This room already has 4 players. Please create a new room or try another link."
-  },
-  "leaveRoom": "Leave Room",
-  "leaveRoomDialog": {
-    "title": "Leave Room?",
-    "description": "Your progress will be lost.",
-    "confirm": "Leave",
-    "cancel": "Stay"
+  "labels": {
+    "you": "You"
   },
   "player": {
     "ready": "Ready",
     "notReady": "Not Ready"
   },
-  "you": "You"
+  "events": {
+    "roomFull": {
+      "title": "Room is full",
+      "description": "This room already has 4 players. Please create a new room or try another link."
+    }
+  },
+  "dialogs": {
+    "leaveRoom": {
+      "title": "Leave Room?",
+      "description": "Your progress will be lost.",
+      "confirm": "Leave",
+      "cancel": "Stay"
+    }
+  },
+  "status": {
+    "success": {
+      "copyRoomLink": {
+        "title": "Link copied!",
+        "description": "Share it with your friend"
+      }
+    }
+  },
+  "errors": {
+    "clipboard": {
+      "copyRoomLink": {
+        "title": "Could not copy link",
+        "description": "Share it manually with your friend"
+      }
+    },
+    "connection": {
+      "failed": {
+        "title": "Connection failed",
+        "description": "Unable to connect to the server. Check your connection or try again later."
+      },
+      "lost": {
+        "title": "Connection lost",
+        "description": "The connection was interrupted. You have been returned to the home screen."
+      }
+    }
+  }
 }


### PR DESCRIPTION
Restructures the `room` i18n namespace into a consistent nested hierarchy and adds error handling for WebSocket connection failures in `useRoomSession`.

## Changes

- Reorganized `room.json` to group keys under `actions`, `labels`, `events`, `dialogs`, `status`, and `errors` namespaces
- Updated all `t()` calls across `CreateRoomButton`, `JoinRoomInput`, `LeaveRoomButton`, `PlayerItem`, and `RoomIdDisplay` to use the new key paths
- Updated `useCopyRoomLink` toast keys to `status.success.copyRoomLink` and `errors.clipboard.copyRoomLink`
- Updated `useRoomSession` room-full toast to use `events.roomFull`
- Added `onError` handler in `useRoomSession` to show a connection failure toast and redirect home
- Added `onClose` handler in `useRoomSession` to notify the user when the connection is lost
- Changed not-ready `Badge` variant in `PlayerItem` from `destructive` to `secondary`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- CreateRoomButton.tsx — Updated translation key from `createRoom` to `actions.createRoom`
- JoinRoomInput.tsx — Updated translation key from `joinRoom` to `actions.joinRoom`
- LeaveRoomButton.tsx — Updated translation keys to nested paths under `actions.leaveRoom` and `dialogs.leaveRoom.*`
- PlayerItem.tsx — Updated "you" label translation key to `labels.you`; changed not-ready badge variant from `destructive` to `secondary`
- RoomIdDisplay.tsx — Updated translation key from `copyRoomLink` to `actions.copyRoomLink`
- useCopyRoomLink.ts — Updated toast translation keys to `status.success.copyRoomLink.*` and `errors.clipboard.copyRoomLink.*`
- useRoomSession.ts — Updated room-full toast to `events.roomFull.*`; added `onError` handler showing `errors.connection.failed.*` toast and redirecting home; added `onClose` handler showing `errors.connection.lost.*` toast and redirecting home unless the close was marked intentional; prevent redirect/toast on intentional socket close
- src/locales/en/room.json — Restructured flat translation keys into nested hierarchy: `actions`, `labels`, `events`, `dialogs`, `status.success`, and `errors.*`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->