### PR TITLE
Guard onMessage against malformed JSON and unknown senders

### DIFF
--- a/party/index.ts
+++ b/party/index.ts
@@ -38,7 +38,17 @@ export default class Server implements Party.Server {
   }
 
   onMessage(message: string, sender: Party.Connection) {
-    const msg = JSON.parse(message)
+    let msg: unknown
+    try {
+      msg = JSON.parse(message)
+    } catch {
+      return
+    }
+
+    if (!this.players[sender.id]) return
+
+    if (typeof msg !== "object" || msg === null || !("type" in msg)) return
+
     const ready =
       msg.type === "READY" ? true : msg.type === "UNREADY" ? false : null
     if (ready === null) return


### PR DESCRIPTION
Fixes two unhandled exceptions in `onMessage` that could crash the room
handler for all connected clients. A malformed JSON frame from any client
would propagate an unhandled `SyntaxError`; a message arriving after the
sender disconnected would throw a null access on the player lookup. Both
guards mirror the existing defensive pattern already present in `onConnect`
and `onClose`.

## Changes

- Wrapped `JSON.parse` in try/catch in `onMessage` — malformed frames are silently discarded
- Added early return in `onMessage` when `sender.id` is absent from `this.players` — late messages from disconnected clients are ignored
- Added object shape guard (`typeof`, null check, `"type" in msg`) to narrow `unknown` before accessing `.type`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## party/index.ts

- Wrap `JSON.parse` in try/catch to handle malformed JSON frames; silently return on parse failure
- Add early return if sender is not found in `this.players` to ignore late messages from disconnected clients
- Add type guard check: validate `msg` is a non-null object with a `type` field before accessing `.type` property

<!-- end of auto-generated comment: release notes by coderabbit.ai -->