### PR TITLE
Surface initialization errors by awaiting i18nReady before mount

### DIFF
--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -2,15 +2,11 @@ import i18n from "i18next"
 import { initReactI18next } from "react-i18next"
 import en from "@/locales/index"
 
-i18n.use(initReactI18next).init({
-  resources: {
-    en,
-  },
-  lng: "en", // default language
+export const i18nReady = i18n.use(initReactI18next).init({
+  resources: { en },
+  lng: "en",
   fallbackLng: "en",
-  interpolation: {
-    escapeValue: false, // React handles XSS
-  },
+  interpolation: { escapeValue: false },
 })
 
 export default i18n

--- a/src/lib/roomId.ts
+++ b/src/lib/roomId.ts
@@ -3,7 +3,6 @@ export const ROOM_CODE_LENGTH = 6
 export function generateRoomId() {
   return Math.random()
     .toString(36)
-    .padEnd(2 + ROOM_CODE_LENGTH, "0")
     .substring(2, 2 + ROOM_CODE_LENGTH)
     .toUpperCase()
 }

--- a/src/lib/roomId.ts
+++ b/src/lib/roomId.ts
@@ -3,6 +3,7 @@ export const ROOM_CODE_LENGTH = 6
 export function generateRoomId() {
   return Math.random()
     .toString(36)
+    .padEnd(2 + ROOM_CODE_LENGTH, "0")
     .substring(2, 2 + ROOM_CODE_LENGTH)
     .toUpperCase()
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -9,19 +9,27 @@ import { Toaster } from "@/components/ui/sonner.tsx"
 import { router } from "@/routes/index.tsx"
 import { i18nReady } from "@/lib/i18n"
 
-i18nReady
-  .then(() => {
-    createRoot(document.getElementById("root")!).render(
-      <StrictMode>
-        <ThemeProvider>
-          <div className="flex h-svh min-h-0 w-full items-center justify-center p-4">
-            <RouterProvider router={router} />
-          </div>
-          <Toaster position="top-center" />
-        </ThemeProvider>
-      </StrictMode>
-    )
-  })
-  .catch((err: unknown) => {
-    console.error("[i18n] Initialization failed:", err)
-  })
+const onI18nReady = () => {
+  const rootEl = document.getElementById("root")
+  if (!rootEl) {
+    throw new Error("[root] #root element not found in DOM")
+  }
+  createRoot(rootEl).render(
+    <StrictMode>
+      <ThemeProvider>
+        <div className="flex h-svh min-h-0 w-full items-center justify-center p-4">
+          <RouterProvider router={router} />
+        </div>
+        <Toaster position="top-center" />
+      </ThemeProvider>
+    </StrictMode>
+  )
+}
+
+const onI18nFailed = (err: unknown) => {
+  console.error("[i18n] Initialization failed:", err)
+}
+
+i18nReady.then(onI18nReady, onI18nFailed).catch((err: unknown) => {
+  console.error("[root] Mount/render failed:", err)
+})

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,14 +7,21 @@ import { ThemeProvider } from "@/components/theme-provider.tsx"
 import { RouterProvider } from "react-router"
 import { Toaster } from "@/components/ui/sonner.tsx"
 import { router } from "@/routes/index.tsx"
+import { i18nReady } from "@/lib/i18n"
 
-createRoot(document.getElementById("root")!).render(
-  <StrictMode>
-    <ThemeProvider>
-      <div className="flex h-svh min-h-0 w-full items-center justify-center p-4">
-        <RouterProvider router={router} />
-      </div>
-      <Toaster position="top-center" />
-    </ThemeProvider>
-  </StrictMode>
-)
+i18nReady
+  .then(() => {
+    createRoot(document.getElementById("root")!).render(
+      <StrictMode>
+        <ThemeProvider>
+          <div className="flex h-svh min-h-0 w-full items-center justify-center p-4">
+            <RouterProvider router={router} />
+          </div>
+          <Toaster position="top-center" />
+        </ThemeProvider>
+      </StrictMode>
+    )
+  })
+  .catch((err: unknown) => {
+    console.error("[i18n] Initialization failed:", err)
+  })


### PR DESCRIPTION
`i18n.init()` returns a Promise whose rejection was previously unhandled, silently swallowing misconfiguration errors and leaving the app rendering with broken translations.

This fix exports `i18nReady` from `i18n.ts` and defers `createRoot` until the Promise resolves, guaranteeing translations are ready before first render. Initialization failures are now caught and logged explicitly.

## Changes

- Exported `i18nReady` Promise from `src/lib/i18n.ts` to expose init result
- Wrapped `createRoot(...).render()` in `i18nReady.then()` in `src/main.tsx` to block mount until i18n is ready
- Added `.catch()` in `src/main.tsx` to surface i18n init failures via `console.error`
- Replaced `import "@/lib/i18n"` with named import `{ i18nReady }` in `src/main.tsx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**Changed Components:**

- **src/lib/i18n.ts**: Export `i18nReady` Promise from `i18n.init()` to expose i18n initialization state; reformat initialization options for conciseness

- **src/main.tsx**: Import and await `i18nReady` before rendering React root to ensure translations are ready; add `.catch()` handler to log i18n initialization failures via `console.error()`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->