### PR TITLE
Ensure full-length padding for room IDs

### DIFF
--- a/src/lib/roomId.ts
+++ b/src/lib/roomId.ts
@@ -3,6 +3,7 @@ export const ROOM_CODE_LENGTH = 6
 export function generateRoomId() {
   return Math.random()
     .toString(36)
+    .padEnd(2 + ROOM_CODE_LENGTH, "0")
     .substring(2, 2 + ROOM_CODE_LENGTH)
     .toUpperCase()
 }


### PR DESCRIPTION
`generateRoomId` could produce short codes when `Math.random()` returns a
value with fewer than 8 significant base-36 digits. Added `.padEnd()` before
`.substring()` to guarantee the slice always has enough characters, so room
codes are always `ROOM_CODE_LENGTH` chars long.

## Changes

- Fixed `generateRoomId` in `roomId.ts` to pad the base-36 string before slicing, preventing short room codes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**src/lib/roomId.ts**
- `generateRoomId()`: Added `.padEnd(2 + ROOM_CODE_LENGTH, "0")` to pad the base-36 string before substring extraction, ensuring room codes always have the expected fixed length (ROOM_CODE_LENGTH = 6 characters) regardless of Math.random() precision

<!-- end of auto-generated comment: release notes by coderabbit.ai -->