### PR TITLE
Implement tile bag, rack management, and game start flow

### DIFF
--- a/party/constants.ts
+++ b/party/constants.ts
@@ -1,2 +1,38 @@
 export const MAX_PLAYERS = 4
 export const MIN_PLAYERS = 2
+
+export const TILE_DISTRIBUTION: {
+  letter: string
+  points: number
+  count: number
+}[] = [
+  { letter: "A", points: 1, count: 9 },
+  { letter: "B", points: 3, count: 2 },
+  { letter: "C", points: 3, count: 2 },
+  { letter: "D", points: 2, count: 4 },
+  { letter: "E", points: 1, count: 12 },
+  { letter: "F", points: 4, count: 2 },
+  { letter: "G", points: 2, count: 3 },
+  { letter: "H", points: 4, count: 2 },
+  { letter: "I", points: 1, count: 9 },
+  { letter: "J", points: 8, count: 1 },
+  { letter: "K", points: 5, count: 1 },
+  { letter: "L", points: 1, count: 4 },
+  { letter: "M", points: 3, count: 2 },
+  { letter: "N", points: 1, count: 6 },
+  { letter: "O", points: 1, count: 8 },
+  { letter: "P", points: 3, count: 2 },
+  { letter: "Q", points: 10, count: 1 },
+  { letter: "R", points: 1, count: 6 },
+  { letter: "S", points: 1, count: 4 },
+  { letter: "T", points: 1, count: 6 },
+  { letter: "U", points: 1, count: 4 },
+  { letter: "V", points: 4, count: 2 },
+  { letter: "W", points: 4, count: 2 },
+  { letter: "X", points: 8, count: 1 },
+  { letter: "Y", points: 4, count: 2 },
+  { letter: "Z", points: 10, count: 1 },
+  { letter: "", points: 0, count: 2 }, // blank tiles
+]
+
+export const RACK_SIZE = 7

--- a/party/index.ts
+++ b/party/index.ts
@@ -45,6 +45,11 @@ function drawTiles(
   return { drawn, remaining }
 }
 
+function toPublicPlayer(p: Player): Omit<Player, "rack"> {
+  const { rack: _, ...pub } = p
+  return pub
+}
+
 export default class Server implements Party.Server {
   players: Record<string, Player> = {}
   bag: Tile[] = []
@@ -53,16 +58,13 @@ export default class Server implements Party.Server {
   constructor(readonly room: Party.Room) {}
 
   onConnect(conn: Party.Connection) {
-    if (this.gameStarted && !this.players[conn.id]) {
-      conn.send(JSON.stringify({ type: "ROOM_FULL" }))
-      conn.close()
-      return
-    }
-
-    if (Object.keys(this.players).length >= MAX_PLAYERS) {
-      conn.send(JSON.stringify({ type: "ROOM_FULL" }))
-      conn.close()
-      return
+    const isReconnect = !!this.players[conn.id]
+    if (!isReconnect) {
+      if (this.gameStarted || Object.keys(this.players).length >= MAX_PLAYERS) {
+        conn.send(JSON.stringify({ type: "ROOM_FULL" }))
+        conn.close()
+        return
+      }
     }
 
     const existing = this.players[conn.id]
@@ -89,7 +91,7 @@ export default class Server implements Party.Server {
     this.room.broadcast(
       JSON.stringify({
         type: "ROOM_STATE",
-        players: Object.values(this.players),
+        players: Object.values(this.players).map(toPublicPlayer),
       })
     )
   }
@@ -104,7 +106,7 @@ export default class Server implements Party.Server {
     this.room.broadcast(
       JSON.stringify({
         type: "ROOM_STATE",
-        players: Object.values(this.players),
+        players: Object.values(this.players).map(toPublicPlayer),
       })
     )
   }
@@ -132,7 +134,12 @@ export default class Server implements Party.Server {
     if (allReady) {
       this.startGame()
     } else {
-      this.room.broadcast(JSON.stringify({ type: "ROOM_STATE", players: list }))
+      this.room.broadcast(
+        JSON.stringify({
+          type: "ROOM_STATE",
+          players: list.map(toPublicPlayer),
+        })
+      )
     }
   }
   startGame() {
@@ -170,7 +177,8 @@ export default class Server implements Party.Server {
     this.bag = remaining
     player.rack.push(...drawn)
 
-    const conn = [...this.room.getConnections()].find((c) => c.id === connId)
-    conn?.send(JSON.stringify({ type: "RACK_STATE", tiles: player.rack }))
+    this.room
+      .getConnection(connId)
+      ?.send(JSON.stringify({ type: "RACK_STATE", tiles: player.rack }))
   }
 }

--- a/party/index.ts
+++ b/party/index.ts
@@ -10,6 +10,7 @@ interface Player {
   id: string
   ready: boolean
   rack: Tile[]
+  connected: boolean
 }
 
 export interface Tile {
@@ -29,8 +30,10 @@ function buildBag(): Tile[] {
 
 function shuffleBag(bag: Tile[]): Tile[] {
   const shuffled = [...bag]
+  const rand = new Uint32Array(1)
   for (let i = shuffled.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1))
+    crypto.getRandomValues(rand)
+    const j = rand[0] % (i + 1)
     ;[shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]]
   }
   return shuffled
@@ -74,16 +77,27 @@ export default class Server implements Party.Server {
         id: conn.id,
         ready: false,
         rack: [],
+        connected: true,
       }
     }
 
     const player = this.players[conn.id]
+    player.connected = true
 
     if (player.rack.length > 0) {
       conn.send(
         JSON.stringify({
           type: "RACK_STATE",
           tiles: player.rack,
+        })
+      )
+    }
+
+    if (isReconnect && this.gameStarted) {
+      conn.send(
+        JSON.stringify({
+          type: "GAME_START",
+          roomId: this.room.id,
         })
       )
     }
@@ -97,7 +111,17 @@ export default class Server implements Party.Server {
   }
 
   onClose(conn: Party.Connection) {
+    const player = this.players[conn.id]
     if (this.gameStarted) {
+      if (player) {
+        player.connected = false
+        this.room.broadcast(
+          JSON.stringify({
+            type: "ROOM_STATE",
+            players: Object.values(this.players).map(toPublicPlayer),
+          })
+        )
+      }
       return
     }
 
@@ -148,15 +172,16 @@ export default class Server implements Party.Server {
 
     this.bag = shuffleBag(buildBag())
 
-    for (const conn of this.room.getConnections()) {
-      const player = this.players[conn.id]
-      if (!player) continue
+    for (const id in this.players) {
+      const player = this.players[id]
 
       const { drawn, remaining } = drawTiles(this.bag, RACK_SIZE)
       this.bag = remaining
       player.rack = drawn
 
-      conn.send(JSON.stringify({ type: "RACK_STATE", tiles: drawn }))
+      this.room
+        .getConnection(id)
+        ?.send(JSON.stringify({ type: "RACK_STATE", tiles: drawn }))
     }
 
     this.room.broadcast(JSON.stringify({ type: "GAME_START" }))

--- a/party/index.ts
+++ b/party/index.ts
@@ -29,7 +29,7 @@ function buildBag(): Tile[] {
 
 function shuffleBag(bag: Tile[]): Tile[] {
   const shuffled = [...bag]
-  for (let i = shuffled.length - 1; i > 1; i--) {
+  for (let i = shuffled.length - 1; i > 0; i--) {
     const j = Math.floor(Math.random() * (i + 1))
     ;[shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]]
   }
@@ -48,17 +48,44 @@ function drawTiles(
 export default class Server implements Party.Server {
   players: Record<string, Player> = {}
   bag: Tile[] = []
+  gameStarted = false
 
   constructor(readonly room: Party.Room) {}
 
   onConnect(conn: Party.Connection) {
+    if (this.gameStarted && !this.players[conn.id]) {
+      conn.send(JSON.stringify({ type: "ROOM_FULL" }))
+      conn.close()
+      return
+    }
+
     if (Object.keys(this.players).length >= MAX_PLAYERS) {
       conn.send(JSON.stringify({ type: "ROOM_FULL" }))
       conn.close()
       return
     }
-    this.players[conn.id] = { id: conn.id, ready: false }
-    conn.send(JSON.stringify({ type: "JOINED", myId: conn.id }))
+
+    const existing = this.players[conn.id]
+
+    if (!existing) {
+      this.players[conn.id] = {
+        id: conn.id,
+        ready: false,
+        rack: [],
+      }
+    }
+
+    const player = this.players[conn.id]
+
+    if (player.rack.length > 0) {
+      conn.send(
+        JSON.stringify({
+          type: "RACK_STATE",
+          tiles: player.rack,
+        })
+      )
+    }
+
     this.room.broadcast(
       JSON.stringify({
         type: "ROOM_STATE",
@@ -68,7 +95,12 @@ export default class Server implements Party.Server {
   }
 
   onClose(conn: Party.Connection) {
+    if (this.gameStarted) {
+      return
+    }
+
     delete this.players[conn.id]
+
     this.room.broadcast(
       JSON.stringify({
         type: "ROOM_STATE",
@@ -98,12 +130,15 @@ export default class Server implements Party.Server {
     const allReady = list.length >= MIN_PLAYERS && list.every((p) => p.ready)
 
     if (allReady) {
-      this.room.broadcast(JSON.stringify({ type: "GAME_START" }))
+      this.startGame()
     } else {
       this.room.broadcast(JSON.stringify({ type: "ROOM_STATE", players: list }))
     }
   }
   startGame() {
+    if (this.gameStarted) return
+    this.gameStarted = true
+
     this.bag = shuffleBag(buildBag())
 
     for (const conn of this.room.getConnections()) {

--- a/party/index.ts
+++ b/party/index.ts
@@ -1,13 +1,53 @@
 import type * as Party from "partykit/server"
-import { MAX_PLAYERS, MIN_PLAYERS } from "./constants"
+import {
+  MAX_PLAYERS,
+  MIN_PLAYERS,
+  RACK_SIZE,
+  TILE_DISTRIBUTION,
+} from "./constants"
 
 interface Player {
   id: string
   ready: boolean
+  rack: Tile[]
+}
+
+export interface Tile {
+  letter: string
+  points: number
+}
+
+function buildBag(): Tile[] {
+  const bag: Tile[] = []
+  for (const { letter, points, count } of TILE_DISTRIBUTION) {
+    for (let i = 0; i < count; i++) {
+      bag.push({ letter, points })
+    }
+  }
+  return bag
+}
+
+function shuffleBag(bag: Tile[]): Tile[] {
+  const shuffled = [...bag]
+  for (let i = shuffled.length - 1; i > 1; i--) {
+    const j = Math.floor(Math.random() * (i + 1))
+    ;[shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]]
+  }
+  return shuffled
+}
+
+function drawTiles(
+  bag: Tile[],
+  count: number
+): { drawn: Tile[]; remaining: Tile[] } {
+  const remaining = [...bag]
+  const drawn = remaining.splice(0, count)
+  return { drawn, remaining }
 }
 
 export default class Server implements Party.Server {
   players: Record<string, Player> = {}
+  bag: Tile[] = []
 
   constructor(readonly room: Party.Room) {}
 
@@ -46,7 +86,6 @@ export default class Server implements Party.Server {
     }
 
     if (!this.players[sender.id]) return
-
     if (typeof msg !== "object" || msg === null || !("type" in msg)) return
 
     const ready =
@@ -63,5 +102,40 @@ export default class Server implements Party.Server {
     } else {
       this.room.broadcast(JSON.stringify({ type: "ROOM_STATE", players: list }))
     }
+  }
+  startGame() {
+    this.bag = shuffleBag(buildBag())
+
+    for (const conn of this.room.getConnections()) {
+      const player = this.players[conn.id]
+      if (!player) continue
+
+      const { drawn, remaining } = drawTiles(this.bag, RACK_SIZE)
+      this.bag = remaining
+      player.rack = drawn
+
+      conn.send(JSON.stringify({ type: "RACK_STATE", tiles: drawn }))
+    }
+
+    this.room.broadcast(JSON.stringify({ type: "GAME_START" }))
+  }
+
+  refillRack(connId: string) {
+    const player = this.players[connId]
+    if (!player) return
+
+    const needed = RACK_SIZE - player.rack.length
+    if (needed <= 0 || this.bag.length === 0) return
+
+    const { drawn, remaining } = drawTiles(
+      this.bag,
+      Math.min(needed, this.bag.length)
+    )
+
+    this.bag = remaining
+    player.rack.push(...drawn)
+
+    const conn = [...this.room.getConnections()].find((c) => c.id === connId)
+    conn?.send(JSON.stringify({ type: "RACK_STATE", tiles: player.rack }))
   }
 }

--- a/party/tiles.ts
+++ b/party/tiles.ts
@@ -1,0 +1,6 @@
+export interface Tile {
+  letter: string
+  points: number
+}
+
+

--- a/party/tiles.ts
+++ b/party/tiles.ts
@@ -1,6 +1,0 @@
-export interface Tile {
-  letter: string
-  points: number
-}
-
-

--- a/src/components/game/Rack.tsx
+++ b/src/components/game/Rack.tsx
@@ -7,7 +7,7 @@ interface RackProps {
 
 export default function Rack({ tiles }: RackProps) {
   return (
-    <div className="flex h-20 w-full items-center justify-center gap-1 rounded-xl bg-border px-2">
+    <div className="flex w-auto items-center justify-center gap-1 rounded-xl bg-border px-2 py-2">
       {tiles.map((tile, i) => (
         <Tile key={i} tile={tile} />
       ))}

--- a/src/components/game/Rack.tsx
+++ b/src/components/game/Rack.tsx
@@ -7,7 +7,7 @@ interface RackProps {
 
 export default function Rack({ tiles }: RackProps) {
   return (
-    <div className="flex w-auto items-center justify-center gap-1 rounded-xl bg-border px-2 py-2">
+    <div className="@container flex w-auto items-center justify-center gap-1 rounded-xl bg-border px-2 py-2">
       {tiles.map((tile, i) => (
         <Tile key={i} tile={tile} />
       ))}

--- a/src/components/game/Rack.tsx
+++ b/src/components/game/Rack.tsx
@@ -1,3 +1,16 @@
-export default function Rack() {
-  return <div className="h-20 rounded-xl bg-border"></div>
+import Tile from "@/components/game/Tile"
+import type { TileType } from "@/types/room"
+
+interface RackProps {
+  tiles: TileType[]
+}
+
+export default function Rack({ tiles }: RackProps) {
+  return (
+    <div className="flex h-20 w-full items-center justify-center gap-1 rounded-xl bg-border px-2">
+      {tiles.map((tile, i) => (
+        <Tile key={i} tile={tile} />
+      ))}
+    </div>
+  )
 }

--- a/src/components/game/Tile.tsx
+++ b/src/components/game/Tile.tsx
@@ -1,0 +1,1 @@
+export default function Tile({})

--- a/src/components/game/Tile.tsx
+++ b/src/components/game/Tile.tsx
@@ -1,8 +1,8 @@
 import { cn } from "@/lib/utils"
 import type { TileType } from "@/types/room"
 
-const LETTER_SIZE = "text-[clamp(0.75rem,3.5cqw,1.5rem)]"
-const POINTS_SIZE = "text-[clamp(0.4rem,1.5cqw,0.75rem)]"
+const LETTER_SIZE = "text-[clamp(1rem,3.5cqw,1.5rem)]"
+const POINTS_SIZE = "text-[clamp(0.5rem,1.5cqw,0.75rem)]"
 
 interface TileProps {
   tile: TileType
@@ -10,8 +10,8 @@ interface TileProps {
 
 export default function Tile({ tile }: TileProps) {
   return (
-    <div className="relative aspect-square h-full max-h-18 max-w-14 min-w-0 flex-1">
-      <div className="absolute inset-[6%] flex items-center justify-center rounded-[12%] bg-card shadow-sm ring-1 ring-border">
+    <div className="relative aspect-square h-full max-h-14 max-w-14 min-w-0 flex-1">
+      <div className="absolute inset-[6%] flex aspect-square items-center justify-center rounded-[12%] bg-card shadow-sm ring-1 ring-border">
         <span className={cn("font-bold text-foreground", LETTER_SIZE)}>
           {tile.letter}
         </span>

--- a/src/components/game/Tile.tsx
+++ b/src/components/game/Tile.tsx
@@ -1,1 +1,29 @@
-export default function Tile({})
+import { cn } from "@/lib/utils"
+import type { TileType } from "@/types/room"
+
+const LETTER_SIZE = "text-[clamp(0.75rem,3.5cqw,1.5rem)]"
+const POINTS_SIZE = "text-[clamp(0.4rem,1.5cqw,0.75rem)]"
+
+interface TileProps {
+  tile: TileType
+}
+
+export default function Tile({ tile }: TileProps) {
+  return (
+    <div className="relative aspect-square h-full max-h-18 max-w-14 min-w-0 flex-1">
+      <div className="absolute inset-[6%] flex items-center justify-center rounded-[12%] bg-card shadow-sm ring-1 ring-border">
+        <span className={cn("font-bold text-foreground", LETTER_SIZE)}>
+          {tile.letter}
+        </span>
+        <span
+          className={cn(
+            "absolute right-[12%] bottom-[10%] font-medium text-muted-foreground",
+            POINTS_SIZE
+          )}
+        >
+          {tile.points}
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/src/components/room/PlayerList.tsx
+++ b/src/components/room/PlayerList.tsx
@@ -1,18 +1,24 @@
 import type { Player } from "@/types/room"
 import PlayerItem from "./PlayerItem"
+import { getClientId } from "@/lib/clientId"
 
 interface PlayerListProps {
   players: Player[]
-  myId: string
 }
 
-export default function PlayerList({ players, myId }: PlayerListProps) {
+export default function PlayerList({ players }: PlayerListProps) {
+  const myId = getClientId()
+
   return (
     <div className="flex h-full w-auto flex-col justify-center gap-1">
       {players.map((player) => {
-        const isMe = player.id === myId
-
-        return <PlayerItem key={player.id} player={player} isMe={isMe} />
+        return (
+          <PlayerItem
+            key={player.id}
+            player={player}
+            isMe={myId === player.id}
+          />
+        )
       })}
     </div>
   )

--- a/src/components/room/RoomLobby.tsx
+++ b/src/components/room/RoomLobby.tsx
@@ -5,13 +5,12 @@ import ReadyButton from "./ReadyButton"
 interface RoomLobbyProps {
   players: Player[]
   send: (data: object) => void
-  myId: string
 }
 
-export default function RoomLobby({ players, send, myId }: RoomLobbyProps) {
+export default function RoomLobby({ players, send }: RoomLobbyProps) {
   return (
     <div className="flex h-full w-auto flex-col items-center">
-      <PlayerList players={players} myId={myId} />
+      <PlayerList players={players} />
       <ReadyButton send={send} />
     </div>
   )

--- a/src/hooks/game/useGameSession.ts
+++ b/src/hooks/game/useGameSession.ts
@@ -1,4 +1,5 @@
-import type { ServerMessage, Tile } from "@/types/room"
+import { getClientId } from "@/lib/clientId"
+import type { ServerMessage, TileType } from "@/types/room"
 import usePartySocket from "partysocket/react"
 import { useState } from "react"
 import { useTranslation } from "react-i18next"
@@ -8,11 +9,12 @@ import { toast } from "sonner"
 export function useGameSession(roomId: string) {
   const { t } = useTranslation()
   const navigate = useNavigate()
-  const [tiles, setTiles] = useState<Tile[]>([])
+  const [tiles, setTiles] = useState<TileType[]>([])
 
   const socket = usePartySocket({
     host: import.meta.env.VITE_PARTYKIT_HOST ?? "localhost:1999",
     room: roomId,
+    id: getClientId(),
     onMessage(event) {
       try {
         const msg = JSON.parse(event.data) as ServerMessage

--- a/src/hooks/game/useGameSession.ts
+++ b/src/hooks/game/useGameSession.ts
@@ -1,7 +1,7 @@
 import { getClientId } from "@/lib/clientId"
 import type { ServerMessage, TileType } from "@/types/room"
 import usePartySocket from "partysocket/react"
-import { useRef, useState } from "react"
+import { useCallback, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { useNavigate } from "react-router"
 import { toast } from "sonner"
@@ -29,6 +29,7 @@ export function useGameSession(roomId: string) {
       }
     },
     onError() {
+      intentionalClose.current = true
       toast.error(t("errors.connection.failed.title"), {
         description: t("errors.connection.failed.description"),
       })
@@ -44,7 +45,10 @@ export function useGameSession(roomId: string) {
     },
   })
 
-  const send = (data: object) => socket.send(JSON.stringify(data))
+  const send = useCallback(
+    (data: object) => socket.send(JSON.stringify(data)),
+    [socket]
+  )
 
   return { tiles, send }
 }

--- a/src/hooks/game/useGameSession.ts
+++ b/src/hooks/game/useGameSession.ts
@@ -1,15 +1,16 @@
 import { getClientId } from "@/lib/clientId"
 import type { ServerMessage, TileType } from "@/types/room"
 import usePartySocket from "partysocket/react"
-import { useState } from "react"
+import { useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { useNavigate } from "react-router"
 import { toast } from "sonner"
 
 export function useGameSession(roomId: string) {
-  const { t } = useTranslation()
+  const { t } = useTranslation("game")
   const navigate = useNavigate()
   const [tiles, setTiles] = useState<TileType[]>([])
+  const intentionalClose = useRef(false)
 
   const socket = usePartySocket({
     host: import.meta.env.VITE_PARTYKIT_HOST ?? "localhost:1999",
@@ -34,6 +35,8 @@ export function useGameSession(roomId: string) {
       navigate("/")
     },
     onClose() {
+      if (intentionalClose.current) return
+      intentionalClose.current = true
       toast.error(t("errors.connection.lost.title"), {
         description: t("errors.connection.lost.description"),
       })

--- a/src/hooks/game/useGameSession.ts
+++ b/src/hooks/game/useGameSession.ts
@@ -1,0 +1,45 @@
+import type { ServerMessage, Tile } from "@/types/room"
+import usePartySocket from "partysocket/react"
+import { useState } from "react"
+import { useTranslation } from "react-i18next"
+import { useNavigate } from "react-router"
+import { toast } from "sonner"
+
+export function useGameSession(roomId: string) {
+  const { t } = useTranslation()
+  const navigate = useNavigate()
+  const [tiles, setTiles] = useState<Tile[]>([])
+
+  const socket = usePartySocket({
+    host: import.meta.env.VITE_PARTYKIT_HOST ?? "localhost:1999",
+    room: roomId,
+    onMessage(event) {
+      try {
+        const msg = JSON.parse(event.data) as ServerMessage
+        switch (msg.type) {
+          case "RACK_STATE":
+            setTiles(msg.tiles)
+            break
+        }
+      } catch {
+        console.log("non-JSON message:", event.data)
+      }
+    },
+    onError() {
+      toast.error(t("errors.connection.failed.title"), {
+        description: t("errors.connection.failed.description"),
+      })
+      navigate("/")
+    },
+    onClose() {
+      toast.error(t("errors.connection.lost.title"), {
+        description: t("errors.connection.lost.description"),
+      })
+      navigate("/")
+    },
+  })
+
+  const send = (data: object) => socket.send(JSON.stringify(data))
+
+  return { tiles, send }
+}

--- a/src/hooks/room/useRoomSession.ts
+++ b/src/hooks/room/useRoomSession.ts
@@ -4,24 +4,22 @@ import { useNavigate } from "react-router"
 import { useRef, useState } from "react"
 import type { Player, ServerMessage } from "@/types/room"
 import usePartySocket from "partysocket/react"
+import { getClientId } from "@/lib/clientId"
 
 export function useRoomSession(roomId: string) {
   const { t } = useTranslation("room")
   const navigate = useNavigate()
   const [players, setPlayers] = useState<Player[]>([])
-  const [myId, setMyId] = useState<string | null>(null)
   const intentionalClose = useRef(false)
 
   const socket = usePartySocket({
     host: import.meta.env.VITE_PARTYKIT_HOST ?? "localhost:1999",
     room: roomId,
+    id: getClientId(),
     onMessage(event) {
       try {
         const msg = JSON.parse(event.data) as ServerMessage
         switch (msg.type) {
-          case "JOINED":
-            setMyId(msg.myId)
-            break
           case "ROOM_FULL":
             intentionalClose.current = true
             socket.close()
@@ -58,5 +56,5 @@ export function useRoomSession(roomId: string) {
 
   const send = (data: object) => socket.send(JSON.stringify(data))
 
-  return { players, myId, send }
+  return { players, send }
 }

--- a/src/lib/clientId.ts
+++ b/src/lib/clientId.ts
@@ -1,0 +1,8 @@
+export function getClientId(): string {
+  const key = "clientId"
+  const existing = localStorage.getItem(key)
+  if (existing) return existing
+  const id = crypto.randomUUID()
+  localStorage.setItem(key, id)
+  return id
+}

--- a/src/lib/clientId.ts
+++ b/src/lib/clientId.ts
@@ -1,8 +1,12 @@
 export function getClientId(): string {
   const key = "clientId"
-  const existing = localStorage.getItem(key)
-  if (existing) return existing
-  const id = crypto.randomUUID()
-  localStorage.setItem(key, id)
-  return id
+  try {
+    const existing = localStorage.getItem(key)
+    if (existing) return existing
+    const id = crypto.randomUUID()
+    localStorage.setItem(key, id)
+    return id
+  } catch {
+    return crypto.randomUUID()
+  }
 }

--- a/src/lib/clientId.ts
+++ b/src/lib/clientId.ts
@@ -1,3 +1,5 @@
+let fallbackClientId: string | undefined
+
 export function getClientId(): string {
   const key = "clientId"
   try {
@@ -7,6 +9,7 @@ export function getClientId(): string {
     localStorage.setItem(key, id)
     return id
   } catch {
-    return crypto.randomUUID()
+    if (!fallbackClientId) fallbackClientId = crypto.randomUUID()
+    return fallbackClientId
   }
 }

--- a/src/locales/en/game.json
+++ b/src/locales/en/game.json
@@ -1,0 +1,14 @@
+{
+  "errors": {
+    "connection": {
+      "failed": {
+        "title": "Connection failed",
+        "description": "Unable to connect to the server. Check your connection or try again later."
+      },
+      "lost": {
+        "title": "Connection lost",
+        "description": "The connection was interrupted. You have been returned to the home screen."
+      }
+    }
+  }
+}

--- a/src/locales/index.ts
+++ b/src/locales/index.ts
@@ -2,5 +2,6 @@ import room from "@/locales/en/room.json"
 import common from "@/locales/en/common.json"
 import board from "@/locales/en/board.json"
 import errors from "@/locales/en/errors.json"
+import game from "@/locales/en/game.json"
 
-export default { room, common, board, errors }
+export default { room, common, board, errors, game }

--- a/src/pages/Game.tsx
+++ b/src/pages/Game.tsx
@@ -4,11 +4,8 @@ import RoomLayout from "@/components/room/RoomLayout"
 import { useGameSession } from "@/hooks/game/useGameSession"
 import { useParams } from "react-router"
 
-export default function Game() {
-  const { roomId } = useParams<{ roomId: string }>()
-  const { tiles } = useGameSession(roomId!)
-
-  if (!roomId) return null
+function GameSessionView({ roomId }: { roomId: string }) {
+  const { tiles } = useGameSession(roomId)
 
   return (
     <RoomLayout roomId={roomId}>
@@ -18,4 +15,12 @@ export default function Game() {
       <Rack tiles={tiles} />
     </RoomLayout>
   )
+}
+
+export default function Game() {
+  const { roomId } = useParams<{ roomId: string }>()
+
+  if (!roomId) return null
+
+  return <GameSessionView roomId={roomId} />
 }

--- a/src/pages/Game.tsx
+++ b/src/pages/Game.tsx
@@ -1,10 +1,12 @@
 import Board from "@/components/game/Board"
 import Rack from "@/components/game/Rack"
 import RoomLayout from "@/components/room/RoomLayout"
+import { useGameSession } from "@/hooks/game/useGameSession"
 import { useParams } from "react-router"
 
 export default function Game() {
   const { roomId } = useParams<{ roomId: string }>()
+  const { tiles } = useGameSession(roomId!)
 
   if (!roomId) return null
 
@@ -13,7 +15,7 @@ export default function Game() {
       <div className="@container-[size] flex min-h-0 w-full flex-1 items-center justify-center">
         <Board />
       </div>
-      <Rack />
+      <Rack tiles={tiles} />
     </RoomLayout>
   )
 }

--- a/src/pages/Room.tsx
+++ b/src/pages/Room.tsx
@@ -5,14 +5,14 @@ import { useParams } from "react-router"
 
 export default function Room() {
   const { roomId } = useParams<{ roomId: string }>()
-  const { players, myId, send } = useRoomSession(roomId!)
+  const { players, send } = useRoomSession(roomId!)
 
   if (!roomId) return null
 
   return (
     <RoomLayout roomId={roomId}>
       <div className="flex min-h-0 w-full flex-1 flex-col gap-2">
-        <RoomLobby players={players} send={send} myId={myId} />
+        <RoomLobby players={players} send={send} />
       </div>
     </RoomLayout>
   )

--- a/src/types/room.ts
+++ b/src/types/room.ts
@@ -1,9 +1,8 @@
 export type ServerMessage =
-  | { type: "JOINED"; myId: string }
   | { type: "ROOM_STATE"; players: Player[] }
   | { type: "ROOM_FULL" }
   | { type: "GAME_START" }
-  | { type: "RACK_STATE"; tiles: Tile[] }
+  | { type: "RACK_STATE"; tiles: TileType[] }
 
 export type ClientMessage = { type: "READY" } | { type: "UNREADY" }
 
@@ -12,7 +11,7 @@ export interface Player {
   ready: boolean
 }
 
-export interface Tile {
+export interface TileType {
   letter: string
   points: number
 }

--- a/src/types/room.ts
+++ b/src/types/room.ts
@@ -3,10 +3,16 @@ export type ServerMessage =
   | { type: "ROOM_STATE"; players: Player[] }
   | { type: "ROOM_FULL" }
   | { type: "GAME_START" }
+  | { type: "RACK_STATE"; tiles: Tile[] }
 
 export type ClientMessage = { type: "READY" } | { type: "UNREADY" }
 
 export interface Player {
   id: string
   ready: boolean
+}
+
+export interface Tile {
+  letter: string
+  points: number
 }


### PR DESCRIPTION
Implements the tile rack feature, allowing each player to receive and view their 7 private Scrabble tiles when a game starts. Tiles are dealt server-side from a shuffled bag using Fisher-Yates, sent privately to each player via `RACK_STATE`, and rendered in a responsive rack at the bottom of the game screen. Stable client identity via `localStorage` ensures tiles are correctly re-delivered when the game socket reconnects after lobby navigation.

## Changes

- Created `party/index.ts` game logic — tile bag, `shuffleBag` (Fisher-Yates), `drawTiles`, `startGame`, and `refillRack` (wired, awaiting `SUBMIT_WORD`)
- Added `TILE_DISTRIBUTION` and `RACK_SIZE` constants to `party/constants.ts`
- Added `gameStarted` flag to server to block new players mid-game while allowing reconnects
- Created `src/lib/clientId.ts` — stable client identity via `localStorage`, used as `conn.id` across all sockets
- Created `useGameSession` hook — opens game socket with stable `id`, handles `RACK_STATE`, returns `tiles` state
- Created `Tile.tsx` component — letter + point value, proportional sizing via `cqi` and `inset-[6%]` absolute layout
- Created `Rack.tsx` component — flex row of tile slots with `max-w` constraint for responsive sizing on mobile and desktop
- Wired `useGameSession` and `Rack` into `Game.tsx`
- Removed `JOINED` message and `myId` server state — client derives identity from `getClientId()` directly
- Updated `useRoomSession` — added `intentionalClose` ref, `onError`/`onClose` handlers, stable socket `id`
- Removed `myId` prop drilling from `RoomLobby`, `PlayerList` — both now call `getClientId()` directly
- Added `RACK_STATE` to `ServerMessage` union and extracted `TileType` interface in `src/types/room.ts`
- Refactored i18n keys across room components to nested structure (`actions.*`, `dialogs.*`, `errors.*`)
- Fixed `generateRoomId` — added `padEnd` to prevent short IDs when `Math.random()` produces few digits

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- **party/constants.ts**: Added `TILE_DISTRIBUTION` constant with letter/points/count metadata (including blank) and `RACK_SIZE = 7`
- **party/index.ts**: Implemented server-side tile bag and gameplay flow: `Tile` interface, `bag` state, `buildBag`, `shuffleBag` (Fisher–Yates using Math.random), `drawTiles`, `startGame` (deals initial racks), `refillRack`, `gameStarted` flag to block mid-game joins while allowing reconnects; players now have `rack`; server sends `RACK_STATE` for existing racks on reconnect and broadcasts `ROOM_STATE` on connect/disconnect
- **Server ↔ Client protocol**: Added `RACK_STATE` ServerMessage carrying `tiles: TileType[]`; server no longer relies on providing `myId` to clients
- **src/lib/clientId.ts**: New `getClientId()` persisting stable client id in localStorage (falls back to crypto.randomUUID() on error)
- **src/hooks/game/useGameSession.ts**: New hook opens game socket with stable id, handles `RACK_STATE` to maintain `tiles` state, exposes `send`, and shows localized connection error toasts/redirects on socket failures
- **src/hooks/room/useRoomSession.ts**: Now supplies deterministic client id via `getClientId()` to sockets, removed internal `myId`/JOINED handling, returns `{ players, send }`
- **src/components/game/Tile.tsx**: New Tile component rendering letter and point value with proportional sizing and corner points styling
- **src/components/game/Rack.tsx**: Updated to accept `tiles: TileType[]` and render tiles dynamically
- **src/pages/Game.tsx**: Wired `useGameSession` and passed `tiles` into `Rack`
- **src/pages/Room.tsx**: Updated to use `{ players, send }` from `useRoomSession` (drops `myId`)
- **src/components/room/RoomLobby.tsx**: Removed `myId` prop; now accepts only `players` and `send`
- **src/components/room/PlayerList.tsx**: Removed `myId` prop; derives current client id via `getClientId()` when rendering
- **src/types/room.ts**: Added `TileType` interface and `RACK_STATE` to `ServerMessage` union
- **i18n / locales**: Added `src/locales/en/game.json` (connection error messages) and exported it in `src/locales/index.ts`; refactored i18n keys to nested structure where applicable
- **utils/fixes**: Other robustness and behavior tweaks in server flow (re-send racks on reconnect, guard startGame with gameStarted)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->