### PR TITLE
Add CellVariant type and integrate into CellProps

### DIFF
--- a/src/components/game/Cell.tsx
+++ b/src/components/game/Cell.tsx
@@ -1,5 +1,7 @@
+import type { CellVariant } from "@/lib/board"
+
 interface CellProps {
-  variant: string
+  variant: CellVariant
   label?: string
 }
 

--- a/src/lib/board.ts
+++ b/src/lib/board.ts
@@ -84,14 +84,14 @@ export function getCellType(row: number, col: number): CellType {
   return CELL_TYPES[row * BOARD_SIZE + col] ?? "normal"
 }
 
-export const CELL_VARIANTS: Record<CellType, string> = {
+export const CELL_VARIANTS = {
   normal: "bg-background ",
   doubleLetter: "bg-border text-muted-foreground/80",
   tripleLetter: "bg-muted text-muted-foreground",
   doubleWord: "bg-primary/5 text-primary/60",
   tripleWord: "bg-primary/10 text-primary/70",
   center: "bg-primary/10 text-primary/70",
-}
+} as const satisfies Record<CellType, string>
 
 export const CELL_LABELS: Record<CellType, string> = {
   normal: "",
@@ -101,3 +101,5 @@ export const CELL_LABELS: Record<CellType, string> = {
   tripleWord: "TW",
   center: "★",
 }
+
+export type CellVariant = (typeof CELL_VARIANTS)[CellType]


### PR DESCRIPTION
Narrows `variant` prop in `Cell` from `string` to a derived `CellVariant` union type, closing a gap where arbitrary or misspelled Tailwind class strings passed TypeScript's type check silently. The fix tightens `CELL_VARIANTS` with `as const satisfies Record<CellType, string>` so literal class values are preserved rather than widened, then exports `CellVariant` as the indexed union of those literals. `CellProps` now references `CellVariant` directly, giving the compiler full visibility into which values are valid at every call site.

## Changes

- Narrowed `CELL_VARIANTS` in `board.ts` using `as const satisfies Record<CellType, string>` to preserve Tailwind class string literals instead of widening to `string`
- Exported `CellVariant` type from `board.ts` as `(typeof CELL_VARIANTS)[CellType]` — a closed union of the six valid class strings
- Updated `variant` prop in `CellProps` (`Cell.tsx`) from `string` to `CellVariant`, rejecting invalid values at compile time
- Added import of `CellVariant` in `Cell.tsx`