### PR TITLE
Implement usePlacement hook and enhance DnD gameplay features

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.2",
       "dependencies": {
         "@base-ui/react": "^1.3.0",
+        "@dnd-kit/core": "^6.3.1",
         "@fontsource-variable/ibm-plex-sans": "^5.2.8",
         "@tailwindcss/vite": "^4.2.1",
         "class-variance-authority": "^0.7.1",
@@ -660,6 +661,45 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@dotenvx/dotenvx": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@base-ui/react": "^1.3.0",
     "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/utilities": "^6.1.0",
     "@fontsource-variable/ibm-plex-sans": "^5.2.8",
     "@tailwindcss/vite": "^4.2.1",
     "class-variance-authority": "^0.7.1",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.3.0",
+    "@dnd-kit/core": "^6.3.1",
     "@fontsource-variable/ibm-plex-sans": "^5.2.8",
     "@tailwindcss/vite": "^4.2.1",
     "class-variance-authority": "^0.7.1",

--- a/party/constants.ts
+++ b/party/constants.ts
@@ -1,5 +1,6 @@
 export const MAX_PLAYERS = 4
-export const MIN_PLAYERS = 2
+//TODO: Change to 2 before release
+export const MIN_PLAYERS = 1
 
 export const TILE_DISTRIBUTION: {
   letter: string

--- a/src/components/game/Board.tsx
+++ b/src/components/game/Board.tsx
@@ -5,8 +5,14 @@ import {
   CELL_LABELS,
 } from "@/lib/board"
 import Cell from "@/components/game/Cell"
+import type { PlacedTiles } from "@/hooks/game/usePlacement"
+import Tile from "@/components/game/Tile"
 
-export default function Board() {
+interface BoardProps {
+  placements: PlacedTiles
+}
+
+export default function Board({ placements }: BoardProps) {
   return (
     <div className="size-[min(100cqw,100cqh)] rounded-xl bg-border p-[clamp(4px,1cqw,16px)]">
       <div
@@ -18,11 +24,19 @@ export default function Board() {
           const col = i % BOARD_SIZE
           const type = getCellType(row, col)
           return (
-            <Cell
-              key={i}
-              variant={CELL_VARIANTS[type]}
-              label={CELL_LABELS[type]}
-            />
+            <div key={i} className="relative">
+              <Cell
+                cellIndex={i}
+                variant={CELL_VARIANTS[type]}
+                label={CELL_LABELS[type]}
+                isOccupied={!!placements[i]}
+              />
+              {placements[i] && (
+                <div className="absolute inset-0 flex items-center justify-center">
+                  <Tile rackIndex={i} tile={placements[i]} />
+                </div>
+              )}
+            </div>
           )
         })}
       </div>

--- a/src/components/game/Board.tsx
+++ b/src/components/game/Board.tsx
@@ -33,7 +33,7 @@ export default function Board({ placements }: BoardProps) {
               />
               {placements[i] && (
                 <div className="absolute inset-0 flex h-full items-center justify-center">
-                  <Tile rackIndex={i} tile={placements[i]} hidePoints />
+                  <Tile tile={placements[i]} hidePoints />
                 </div>
               )}
             </div>

--- a/src/components/game/Board.tsx
+++ b/src/components/game/Board.tsx
@@ -14,7 +14,7 @@ interface BoardProps {
 
 export default function Board({ placements }: BoardProps) {
   return (
-    <div className="size-[min(100cqw,100cqh)] rounded-xl bg-border p-[clamp(4px,1cqw,16px)]">
+    <div className="@container size-[min(100cqw,100cqh)] rounded-xl bg-border p-[clamp(4px,1cqw,16px)]">
       <div
         className="grid w-full flex-1 gap-px overflow-hidden rounded-lg"
         style={{ gridTemplateColumns: `repeat(${BOARD_SIZE}, 1fr)` }}
@@ -32,8 +32,8 @@ export default function Board({ placements }: BoardProps) {
                 isOccupied={!!placements[i]}
               />
               {placements[i] && (
-                <div className="absolute inset-0 flex items-center justify-center">
-                  <Tile rackIndex={i} tile={placements[i]} />
+                <div className="absolute inset-0 flex h-full items-center justify-center">
+                  <Tile rackIndex={i} tile={placements[i]} hidePoints />
                 </div>
               )}
             </div>

--- a/src/components/game/Cell.tsx
+++ b/src/components/game/Cell.tsx
@@ -1,14 +1,32 @@
-import type { CellVariant } from "@/lib/board"
+import { cn } from "@/lib/utils"
+import { useDroppable } from "@dnd-kit/core"
 
 interface CellProps {
-  variant: CellVariant
+  variant: string
   label?: string
+  cellIndex: number
+  isOccupied: boolean
 }
 
-export default function Cell({ variant, label }: CellProps) {
+export default function Cell({
+  variant,
+  label,
+  cellIndex,
+  isOccupied,
+}: CellProps) {
+  const { setNodeRef, isOver } = useDroppable({
+    id: `cell-${cellIndex}`,
+    disabled: isOccupied,
+    data: { cellIndex },
+  })
+
   return (
     <div
-      className={`flex aspect-square items-center justify-center ${variant}`}
+      ref={setNodeRef}
+      className={cn(
+        `relative flex aspect-square items-center justify-center ${variant}`,
+        isOver && !isOccupied && "ring-2 ring-primary/50 ring-inset"
+      )}
     >
       <span className="text-[clamp(0.6rem,1.5cqw,1.5rem)] font-bold">
         {label}

--- a/src/components/game/Rack.tsx
+++ b/src/components/game/Rack.tsx
@@ -2,15 +2,23 @@ import Tile from "@/components/game/Tile"
 import type { TileType } from "@/types/room"
 
 interface RackProps {
-  tiles: TileType[]
+  tiles: (TileType | null)[]
+  disabled?: boolean
 }
 
-export default function Rack({ tiles }: RackProps) {
+export default function Rack({ tiles, disabled }: RackProps) {
   return (
     <div className="@container flex w-auto items-center justify-center gap-1 rounded-xl bg-border px-2 py-2">
-      {tiles.map((tile, i) => (
-        <Tile key={i} tile={tile} />
-      ))}
+      {tiles.map((tile, i) =>
+        tile ? (
+          <Tile key={i} tile={tile} rackIndex={i} disabled={disabled} />
+        ) : (
+          <div
+            key={i}
+            className="relative aspect-square h-full max-h-14 max-w-14 min-w-0 flex-1 opacity-0"
+          />
+        )
+      )}
     </div>
   )
 }

--- a/src/components/game/Rack.tsx
+++ b/src/components/game/Rack.tsx
@@ -9,16 +9,18 @@ interface RackProps {
 export default function Rack({ tiles, disabled }: RackProps) {
   return (
     <div className="@container flex w-auto items-center justify-center gap-1 rounded-xl bg-border px-2 py-2">
-      {tiles.map((tile, i) =>
-        tile ? (
-          <Tile key={i} tile={tile} rackIndex={i} disabled={disabled} />
-        ) : (
-          <div
-            key={i}
-            className="relative aspect-square h-full max-h-14 max-w-14 min-w-0 flex-1 opacity-0"
-          />
-        )
-      )}
+      {tiles.map((tile, i) => (
+        <div
+          key={i}
+          className="relative aspect-square h-full max-h-20 max-w-20 min-w-0 flex-1"
+        >
+          {tile ? (
+            <Tile tile={tile} rackIndex={i} disabled={disabled} />
+          ) : (
+            <div className="h-full w-full opacity-0" />
+          )}
+        </div>
+      ))}
     </div>
   )
 }

--- a/src/components/game/Tile.tsx
+++ b/src/components/game/Tile.tsx
@@ -5,16 +5,22 @@ import { CSS } from "@dnd-kit/utilities"
 
 //TODO: fix number overlapping letter when on board. Adjust padding on mobile when on board.
 
-const LETTER_SIZE = "text-[clamp(1rem,3.5cqw,1.5rem)]"
-const POINTS_SIZE = "text-[clamp(0.5rem,1.5cqw,0.75rem)]"
+const LETTER_SIZE = "text-[clamp(1rem,3.5cqw,2rem)]"
+const POINTS_SIZE = "text-[clamp(0.5rem,3.5cqw,1rem)]"
 
 interface TileProps {
   tile: TileType
   rackIndex: number
   disabled?: boolean
+  hidePoints?: boolean
 }
 
-export default function Tile({ tile, rackIndex, disabled }: TileProps) {
+export default function Tile({
+  tile,
+  rackIndex,
+  disabled,
+  hidePoints,
+}: TileProps) {
   const { attributes, listeners, setNodeRef, transform, isDragging } =
     useDraggable({
       id: `rack-${rackIndex}`,
@@ -28,7 +34,7 @@ export default function Tile({ tile, rackIndex, disabled }: TileProps) {
 
   return (
     <div
-      className="relative aspect-square h-full max-h-14 max-w-14 min-w-0 flex-1"
+      className="relative h-full w-full"
       ref={setNodeRef}
       style={style}
       {...listeners}
@@ -36,21 +42,23 @@ export default function Tile({ tile, rackIndex, disabled }: TileProps) {
     >
       <div
         className={cn(
-          "absolute inset-[6%] flex aspect-square items-center justify-center rounded-[12%] bg-card shadow-sm ring-1 ring-border",
+          "absolute inset-[6%] flex items-center justify-center rounded-[12%] bg-card shadow-sm ring-1 ring-border",
           isDragging && "opacity-0"
         )}
       >
         <span className={cn("font-bold text-foreground", LETTER_SIZE)}>
           {tile.letter}
         </span>
-        <span
-          className={cn(
-            "absolute right-[12%] bottom-[10%] font-medium text-muted-foreground",
-            POINTS_SIZE
-          )}
-        >
-          {tile.points}
-        </span>
+        {!hidePoints && (
+          <span
+            className={cn(
+              "absolute right-[16%] bottom-[12%] font-medium text-muted-foreground",
+              POINTS_SIZE
+            )}
+          >
+            {tile.points}
+          </span>
+        )}
       </div>
     </div>
   )

--- a/src/components/game/Tile.tsx
+++ b/src/components/game/Tile.tsx
@@ -1,17 +1,43 @@
 import { cn } from "@/lib/utils"
 import type { TileType } from "@/types/room"
+import { useDraggable } from "@dnd-kit/core"
+import { CSS } from "@dnd-kit/utilities"
 
 const LETTER_SIZE = "text-[clamp(1rem,3.5cqw,1.5rem)]"
 const POINTS_SIZE = "text-[clamp(0.5rem,1.5cqw,0.75rem)]"
 
 interface TileProps {
   tile: TileType
+  rackIndex: number
+  disabled?: boolean
 }
 
-export default function Tile({ tile }: TileProps) {
+export default function Tile({ tile, rackIndex, disabled }: TileProps) {
+  const { attributes, listeners, setNodeRef, transform, isDragging } =
+    useDraggable({
+      id: `rack-${rackIndex}`,
+      disabled,
+      data: { rackIndex: tile },
+    })
+
+  const style = transform
+    ? { transform: CSS.Transform.toString(transform) }
+    : undefined
+
   return (
-    <div className="relative aspect-square h-full max-h-14 max-w-14 min-w-0 flex-1">
-      <div className="absolute inset-[6%] flex aspect-square items-center justify-center rounded-[12%] bg-card shadow-sm ring-1 ring-border">
+    <div
+      className="relative aspect-square h-full max-h-14 max-w-14 min-w-0 flex-1"
+      ref={setNodeRef}
+      style={style}
+      {...listeners}
+      {...attributes}
+    >
+      <div
+        className={cn(
+          "absolute inset-[6%] flex aspect-square items-center justify-center rounded-[12%] bg-card shadow-sm ring-1 ring-border",
+          isDragging && "opacity-0"
+        )}
+      >
         <span className={cn("font-bold text-foreground", LETTER_SIZE)}>
           {tile.letter}
         </span>

--- a/src/components/game/Tile.tsx
+++ b/src/components/game/Tile.tsx
@@ -3,6 +3,8 @@ import type { TileType } from "@/types/room"
 import { useDraggable } from "@dnd-kit/core"
 import { CSS } from "@dnd-kit/utilities"
 
+//TODO: fix number overlapping letter when on board. Adjust padding on mobile when on board.
+
 const LETTER_SIZE = "text-[clamp(1rem,3.5cqw,1.5rem)]"
 const POINTS_SIZE = "text-[clamp(0.5rem,1.5cqw,0.75rem)]"
 

--- a/src/components/game/Tile.tsx
+++ b/src/components/game/Tile.tsx
@@ -3,14 +3,12 @@ import type { TileType } from "@/types/room"
 import { useDraggable } from "@dnd-kit/core"
 import { CSS } from "@dnd-kit/utilities"
 
-//TODO: fix number overlapping letter when on board. Adjust padding on mobile when on board.
-
 const LETTER_SIZE = "text-[clamp(1rem,3.5cqw,2rem)]"
 const POINTS_SIZE = "text-[clamp(0.5rem,3.5cqw,1rem)]"
 
 interface TileProps {
   tile: TileType
-  rackIndex: number
+  rackIndex?: number
   disabled?: boolean
   hidePoints?: boolean
 }
@@ -21,16 +19,18 @@ export default function Tile({
   disabled,
   hidePoints,
 }: TileProps) {
+  const isStatic = rackIndex === undefined
+
   const { attributes, listeners, setNodeRef, transform, isDragging } =
     useDraggable({
       id: `rack-${rackIndex}`,
       disabled,
-      data: { rackIndex: tile },
+      data: { rackIndex, tile },
     })
 
-  const style = transform
-    ? { transform: CSS.Transform.toString(transform) }
-    : undefined
+  const style = {
+    transform: transform ? CSS.Transform.toString(transform) : undefined,
+  }
 
   return (
     <div
@@ -43,7 +43,7 @@ export default function Tile({
       <div
         className={cn(
           "absolute inset-[6%] flex items-center justify-center rounded-[12%] bg-card shadow-sm ring-1 ring-border",
-          isDragging && "opacity-0"
+          !isStatic && isDragging && "opacity-0"
         )}
       >
         <span className={cn("font-bold text-foreground", LETTER_SIZE)}>

--- a/src/components/room/PlayerItem.tsx
+++ b/src/components/room/PlayerItem.tsx
@@ -12,7 +12,10 @@ export default function PlayerItem({ player, isMe }: PlayerItemProps) {
   const { t } = useTranslation("room")
 
   return (
-    <Item variant={`${isMe ? "muted" : "outline"}`} className="w-auto">
+    <Item
+      variant={player.ready ? "muted" : isMe ? "outline" : "default"}
+      className="w-auto"
+    >
       <ItemContent>
         <ItemTitle>
           {player.id}
@@ -20,7 +23,7 @@ export default function PlayerItem({ player, isMe }: PlayerItemProps) {
         </ItemTitle>
       </ItemContent>
       <ItemContent>
-        <Badge variant={`${player.ready ? "default" : "secondary"}`}>
+        <Badge variant={player.ready ? "default" : "secondary"}>
           {t(player.ready ? "player.ready" : "player.notReady")}
         </Badge>
       </ItemContent>

--- a/src/hooks/game/usePlacement.ts
+++ b/src/hooks/game/usePlacement.ts
@@ -1,0 +1,33 @@
+import type { TileType } from "@/types/room"
+import { useCallback, useEffect, useState } from "react"
+
+export type PlacedTiles = Record<number, TileType>
+
+type PlacedIndices = Set<number>
+
+export function usePlacement(initialTiles: TileType[]) {
+  const [placedIndices, setPlacedIndices] = useState<PlacedIndices>(new Set())
+  const [placements, setPlacements] = useState<PlacedTiles>({})
+
+  const rack: (TileType | null)[] = initialTiles.map((tile, i) =>
+    placedIndices.has(i) ? null : tile
+  )
+
+  const placeTile = useCallback(
+    (rackIndex: number, cellIndex: number) => {
+      const tile = initialTiles[rackIndex]
+      if (!tile) return
+
+      setPlacedIndices((prev) => new Set(prev).add(rackIndex))
+      setPlacements((prev) => ({ ...prev, [cellIndex]: tile }))
+    },
+    [initialTiles]
+  )
+
+  const isOccupied = useCallback(
+    (cellIndex: number) => cellIndex in placements,
+    [placements]
+  )
+
+  return { rack, placements, placeTile, isOccupied }
+}

--- a/src/hooks/game/usePlacement.ts
+++ b/src/hooks/game/usePlacement.ts
@@ -1,5 +1,5 @@
 import type { TileType } from "@/types/room"
-import { useCallback, useState } from "react"
+import { useCallback, useEffect, useState } from "react"
 
 export type PlacedTiles = Record<number, TileType>
 
@@ -8,6 +8,14 @@ type PlacedIndices = Set<number>
 export function usePlacement(initialTiles: TileType[]) {
   const [placedIndices, setPlacedIndices] = useState<PlacedIndices>(new Set())
   const [placements, setPlacements] = useState<PlacedTiles>({})
+  const [prevInitialTiles, setPrevInitialTiles] =
+    useState<TileType[]>(initialTiles)
+
+  if (initialTiles !== prevInitialTiles) {
+    setPrevInitialTiles(initialTiles)
+    setPlacedIndices(new Set())
+    setPlacements({})
+  }
 
   const rack: (TileType | null)[] = initialTiles.map((tile, i) =>
     placedIndices.has(i) ? null : tile

--- a/src/hooks/game/usePlacement.ts
+++ b/src/hooks/game/usePlacement.ts
@@ -1,7 +1,7 @@
 import type { TileType } from "@/types/room"
-import { useCallback, useEffect, useState } from "react"
+import { useCallback, useState } from "react"
 
-export type PlacedTiles = Record<number, TileType>
+export type PlacedTiles = Partial<Record<number, TileType>>
 
 type PlacedIndices = Set<number>
 

--- a/src/hooks/game/usePlacement.ts
+++ b/src/hooks/game/usePlacement.ts
@@ -1,5 +1,5 @@
 import type { TileType } from "@/types/room"
-import { useCallback, useEffect, useState } from "react"
+import { useCallback, useState } from "react"
 
 export type PlacedTiles = Record<number, TileType>
 

--- a/src/lib/clientId.ts
+++ b/src/lib/clientId.ts
@@ -13,12 +13,12 @@ export function getClientId(): string {
   try {
     const existing = localStorage.getItem(key)
     if (existing) return existing
-    const id = crypto.randomUUID?.() ?? generateId()
+    const id = globalThis.crypto?.randomUUID?.() ?? generateId()
     localStorage.setItem(key, id)
     return id
   } catch {
     if (!fallbackClientId)
-      fallbackClientId = crypto.randomUUID?.() ?? generateId()
+      fallbackClientId = globalThis.crypto?.randomUUID?.() ?? generateId()
     return fallbackClientId
   }
 }

--- a/src/lib/clientId.ts
+++ b/src/lib/clientId.ts
@@ -1,15 +1,24 @@
 let fallbackClientId: string | undefined
 
+function generateId(): string {
+  return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0
+    const v = c === "x" ? r : (r & 0x3) | 0x8
+    return v.toString(16)
+  })
+}
+
 export function getClientId(): string {
   const key = "clientId"
   try {
     const existing = localStorage.getItem(key)
     if (existing) return existing
-    const id = crypto.randomUUID()
+    const id = crypto.randomUUID?.() ?? generateId()
     localStorage.setItem(key, id)
     return id
   } catch {
-    if (!fallbackClientId) fallbackClientId = crypto.randomUUID()
+    if (!fallbackClientId)
+      fallbackClientId = crypto.randomUUID?.() ?? generateId()
     return fallbackClientId
   }
 }

--- a/src/pages/Game.tsx
+++ b/src/pages/Game.tsx
@@ -2,7 +2,15 @@ import Board from "@/components/game/Board"
 import Rack from "@/components/game/Rack"
 import RoomLayout from "@/components/room/RoomLayout"
 import { useGameSession } from "@/hooks/game/useGameSession"
+import type { PlacedTiles } from "@/hooks/game/usePlacement"
 import { useParams } from "react-router"
+
+const MOCK_PLACEMENTS: PlacedTiles = {
+  112: { letter: "M", points: 3 }, // center (row 7, col 7)
+  113: { letter: "O", points: 1 }, // row 7, col 8
+  114: { letter: "V", points: 4 }, // row 7, col 9
+  115: { letter: "A", points: 1 }, // row 7, col 10
+}
 
 function GameSessionView({ roomId }: { roomId: string }) {
   const { tiles } = useGameSession(roomId)
@@ -10,7 +18,7 @@ function GameSessionView({ roomId }: { roomId: string }) {
   return (
     <RoomLayout roomId={roomId}>
       <div className="@container-[size] flex min-h-0 w-full flex-1 items-center justify-center">
-        <Board />
+        <Board placements={MOCK_PLACEMENTS} />
       </div>
       <Rack tiles={tiles} />
     </RoomLayout>

--- a/src/pages/Game.tsx
+++ b/src/pages/Game.tsx
@@ -29,8 +29,11 @@ function GameSessionView({ roomId }: { roomId: string }) {
   )
 
   const handleDragStart = (event: DragStartEvent) => {
-    const { tile } = event.active.data.current as { tile: TileType }
-    setActiveTile(tile)
+    const activeData = event.active.data.current as
+      | { tile?: TileType }
+      | undefined
+    if (!activeData?.tile) return
+    setActiveTile(activeData.tile)
   }
 
   const handleDragEnd = (event: DragEndEvent) => {
@@ -39,12 +42,17 @@ function GameSessionView({ roomId }: { roomId: string }) {
     const { active, over } = event
     if (!over) return
 
-    const { rackIndex } = active.data.current as { rackIndex: number }
-    const { cellIndex } = over.data.current as { cellIndex: number }
+    const activeData = active.data.current as { rackIndex?: number } | undefined
+    const overData = over.data.current as { cellIndex?: number } | undefined
+    if (
+      typeof activeData?.rackIndex !== "number" ||
+      typeof overData?.cellIndex !== "number"
+    ) {
+      return
+    }
+    if (isOccupied(overData.cellIndex)) return
 
-    if (isOccupied(cellIndex)) return
-
-    placeTile(rackIndex, cellIndex)
+    placeTile(activeData.rackIndex, overData.cellIndex)
   }
 
   return (

--- a/src/pages/Game.tsx
+++ b/src/pages/Game.tsx
@@ -1,34 +1,74 @@
 import Board from "@/components/game/Board"
 import Rack from "@/components/game/Rack"
+import Tile from "@/components/game/Tile"
 import RoomLayout from "@/components/room/RoomLayout"
 import { useGameSession } from "@/hooks/game/useGameSession"
-import type { PlacedTiles } from "@/hooks/game/usePlacement"
+import { usePlacement } from "@/hooks/game/usePlacement"
+import type { TileType } from "@/types/room"
+import {
+  DndContext,
+  DragOverlay,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+  type DragStartEvent,
+} from "@dnd-kit/core"
+import { useState } from "react"
 import { useParams } from "react-router"
-
-const MOCK_PLACEMENTS: PlacedTiles = {
-  112: { letter: "M", points: 3 }, // center (row 7, col 7)
-  113: { letter: "O", points: 1 }, // row 7, col 8
-  114: { letter: "V", points: 4 }, // row 7, col 9
-  115: { letter: "A", points: 1 }, // row 7, col 10
-}
 
 function GameSessionView({ roomId }: { roomId: string }) {
   const { tiles } = useGameSession(roomId)
+  const { rack, placements, placeTile, isOccupied } = usePlacement(tiles)
+  const [activeTile, setActiveTile] = useState<TileType | null>(null)
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: { distance: 8 },
+    })
+  )
+
+  const handleDragStart = (event: DragStartEvent) => {
+    const { tile } = event.active.data.current as { tile: TileType }
+    setActiveTile(tile)
+  }
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    setActiveTile(null)
+
+    const { active, over } = event
+    if (!over) return
+
+    const { rackIndex } = active.data.current as { rackIndex: number }
+    const { cellIndex } = over.data.current as { cellIndex: number }
+
+    if (isOccupied(cellIndex)) return
+
+    placeTile(rackIndex, cellIndex)
+  }
 
   return (
-    <RoomLayout roomId={roomId}>
-      <div className="@container-[size] flex min-h-0 w-full flex-1 items-center justify-center">
-        <Board placements={MOCK_PLACEMENTS} />
-      </div>
-      <Rack tiles={tiles} />
-    </RoomLayout>
+    <DndContext
+      sensors={sensors}
+      onDragStart={handleDragStart}
+      onDragEnd={handleDragEnd}
+    >
+      <RoomLayout roomId={roomId}>
+        <div className="@container-[size] flex min-h-0 w-full flex-1 items-center justify-center">
+          <Board placements={placements} />
+        </div>
+        <Rack tiles={rack} />
+      </RoomLayout>
+
+      <DragOverlay>
+        {activeTile ? <Tile tile={activeTile} /> : null}
+      </DragOverlay>
+    </DndContext>
   )
 }
 
 export default function Game() {
   const { roomId } = useParams<{ roomId: string }>()
-
   if (!roomId) return null
-
   return <GameSessionView roomId={roomId} />
 }

--- a/src/pages/Game.tsx
+++ b/src/pages/Game.tsx
@@ -55,11 +55,16 @@ function GameSessionView({ roomId }: { roomId: string }) {
     placeTile(activeData.rackIndex, overData.cellIndex)
   }
 
+  const handleDragCancel = () => {
+    setActiveTile(null)
+  }
+
   return (
     <DndContext
       sensors={sensors}
       onDragStart={handleDragStart}
       onDragEnd={handleDragEnd}
+      onDragCancel={handleDragCancel}
     >
       <RoomLayout roomId={roomId}>
         <div className="@container-[size] flex min-h-0 w-full flex-1 items-center justify-center">

--- a/src/types/room.ts
+++ b/src/types/room.ts
@@ -1,7 +1,7 @@
 export type ServerMessage =
   | { type: "ROOM_STATE"; players: Player[] }
   | { type: "ROOM_FULL" }
-  | { type: "GAME_START" }
+  | { type: "GAME_START"; currentTurn: string }
   | { type: "RACK_STATE"; tiles: TileType[] }
 
 export type ClientMessage = { type: "READY" } | { type: "UNREADY" }


### PR DESCRIPTION
Implements tile placement on the game board using drag-and-drop functionality. Players can now drag tiles from their rack onto empty cells of the Scrabble board, with visual feedback during dragging. The placement system tracks occupied cells and prevents placing tiles on already-occupied spaces.

## Changes

- Added `@dnd-kit/core` dependency for drag-and-drop functionality
- Created `usePlacement` hook to manage tile placement state on the board and track which tiles have been placed
- Integrated `DndContext` and `DragOverlay` in `Game` component to handle drag-and-drop interactions
- Updated `Board` component to accept `placements` prop and render placed tiles with overlay rendering
- Added `@container` utility to `Board` for proper container query context
- Modified `Cell` component to be a droppable zone with visual feedback (ring highlight) when dragging over empty cells
- Updated `Tile` component to support drag functionality with `useDraggable` hook, including opacity feedback during drag
- Enhanced `Tile` component with `hidePoints` prop to hide point values when displayed on the board
- Updated `Rack` component to accept optional `disabled` prop and render `null` tiles as placeholders for placed tiles
- Improved `Tile` styling with adjusted letter and points sizing via CSS variables
- Updated `PlayerItem` component styling logic to highlight ready players with muted variant
- Modified `GAME_START` message type to include `currentTurn` field for turn tracking
- Changed `MIN_PLAYERS` constant from 2 to 1 (temporary for development, marked with TODO)
- Enhanced `getClientId` utility to fallback to UUID polyfill for environments without `crypto.randomUUID` support

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- **package.json**: Added `@dnd-kit/core` (^6.3.1) dependency for drag-and-drop functionality

- **party/constants.ts**: Lowered MIN_PLAYERS from 2 to 1 (temporary, marked with TODO)

- **src/components/game/Board.tsx**: Made component prop-driven to accept and render `placements`; overlays placed tiles on board cells (Tile rendering in Board no longer requires a `rackIndex`)

- **src/components/game/Cell.tsx**: Enhanced with `useDroppable` to support drag-and-drop targeting; added `cellIndex`/`isOccupied` props and visual ring feedback when dragging over unoccupied cells

- **src/components/game/Rack.tsx**: Updated to support `null` tile slots as placeholders; added optional `disabled` prop; renders placeholders for placed tiles and passes `rackIndex` and `disabled` to child Tile components

- **src/components/game/Tile.tsx**: Refactored to support drag-and-drop via `useDraggable`; added `rackIndex?`, `disabled?`, and `hidePoints?` props; adjusted letter/point sizing constants and drag-time opacity/visibility behavior

- **src/components/room/PlayerItem.tsx**: Refactored JSX/conditional formatting for Item and Badge rendering (multi-line ternaries)

- **src/hooks/game/usePlacement.ts**: New hook to manage tile placements on the board; tracks placed rack indices and `placements`, derives an updated `rack` with `null` for placed tiles, exposes `placeTile` and `isOccupied`, and resets placements when `initialTiles` change

- **src/lib/clientId.ts**: Enhanced clientId generation to use `globalThis.crypto?.randomUUID?.()` with fallback to a local UUID generator; persists generated id to localStorage

- **src/pages/Game.tsx**: Added `GameSessionView` which wraps the game in `DndContext` with pointer sensors and `DragOverlay`; captures drag metadata, validates drops (including occupied cells), calls `placeTile`, and wires `placements`/derived `rack` into `Board` and `Rack`

- **src/types/room.ts**: Extended `GAME_START` server message type to include `currentTurn: string`

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ImDarkly/mova/pull/49?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->