### PR TITLE
Implement turn tracking and scoreboard UI enhancements

### DIFF
--- a/party/index.ts
+++ b/party/index.ts
@@ -57,6 +57,8 @@ export default class Server implements Party.Server {
   players: Record<string, Player> = {}
   bag: Tile[] = []
   gameStarted = false
+  playerOrder: string[] = []
+  currentTurn: string = ""
 
   constructor(readonly room: Party.Room) {}
 
@@ -68,6 +70,7 @@ export default class Server implements Party.Server {
         conn.close()
         return
       }
+      this.playerOrder.push(conn.id)
     }
 
     const existing = this.players[conn.id]
@@ -146,29 +149,47 @@ export default class Server implements Party.Server {
     if (!this.players[sender.id]) return
     if (typeof msg !== "object" || msg === null || !("type" in msg)) return
 
-    const ready =
-      msg.type === "READY" ? true : msg.type === "UNREADY" ? false : null
-    if (ready === null) return
+    if (msg.type === "READY" || msg.type === "UNREADY") {
+      this.players[sender.id].ready = msg.type === "READY"
 
-    this.players[sender.id].ready = ready
+      const list = Object.values(this.players)
+      const allReady = list.length >= MIN_PLAYERS && list.every((p) => p.ready)
 
-    const list = Object.values(this.players)
-    const allReady = list.length >= MIN_PLAYERS && list.every((p) => p.ready)
+      if (allReady) {
+        this.startGame()
+      } else {
+        this.room.broadcast(
+          JSON.stringify({
+            type: "ROOM_STATE",
+            players: list.map(toPublicPlayer),
+          })
+        )
+      }
+    }
 
-    if (allReady) {
-      this.startGame()
-    } else {
+    if (msg.type === "SUBMIT_TURN") {
+      if (sender.id === this.currentTurn) return
+
+      this.refillRack(sender.id)
+
+      const currentIndex = this.playerOrder.indexOf(this.currentTurn)
+      const nextIndex = (currentIndex + 1) % this.playerOrder.length
+      this.currentTurn = this.playerOrder[nextIndex]
+
       this.room.broadcast(
         JSON.stringify({
-          type: "ROOM_STATE",
-          players: list.map(toPublicPlayer),
+          type: "TURN_CHANGE",
+          currentTurn: this.currentTurn,
         })
       )
+      return
     }
   }
+
   startGame() {
     if (this.gameStarted) return
     this.gameStarted = true
+    this.currentTurn = this.playerOrder[0]
 
     this.bag = shuffleBag(buildBag())
 
@@ -184,7 +205,9 @@ export default class Server implements Party.Server {
         ?.send(JSON.stringify({ type: "RACK_STATE", tiles: drawn }))
     }
 
-    this.room.broadcast(JSON.stringify({ type: "GAME_START" }))
+    this.room.broadcast(
+      JSON.stringify({ type: "GAME_START", currentTurn: this.currentTurn })
+    )
   }
 
   refillRack(connId: string) {

--- a/party/index.ts
+++ b/party/index.ts
@@ -62,6 +62,20 @@ export default class Server implements Party.Server {
 
   constructor(readonly room: Party.Room) {}
 
+  advanceToNextConnectedPlayer() {
+    const len = this.playerOrder.length
+    if (len === 0) return
+    const start = this.playerOrder.indexOf(this.currentTurn)
+    for (let i = 1; i <= len; i++) {
+      const candidate = this.playerOrder[(start + i) % len]
+      const p = this.players[candidate]
+      if (p && p.connected) {
+        this.currentTurn = candidate
+        return
+      }
+    }
+  }
+
   onConnect(conn: Party.Connection) {
     const isReconnect = !!this.players[conn.id]
     if (!isReconnect) {
@@ -119,6 +133,17 @@ export default class Server implements Party.Server {
     if (this.gameStarted) {
       if (player) {
         player.connected = false
+
+        if (this.currentTurn === conn.id) {
+          this.advanceToNextConnectedPlayer()
+          this.room.broadcast(
+            JSON.stringify({
+              type: "TURN_CHANGE",
+              currentTurn: this.currentTurn,
+            })
+          )
+        }
+
         this.room.broadcast(
           JSON.stringify({
             type: "ROOM_STATE",
@@ -130,6 +155,7 @@ export default class Server implements Party.Server {
     }
 
     delete this.players[conn.id]
+    this.playerOrder = this.playerOrder.filter((id) => id !== conn.id)
 
     this.room.broadcast(
       JSON.stringify({
@@ -172,10 +198,7 @@ export default class Server implements Party.Server {
       if (sender.id !== this.currentTurn) return
 
       this.refillRack(sender.id)
-
-      const currentIndex = this.playerOrder.indexOf(this.currentTurn)
-      const nextIndex = (currentIndex + 1) % this.playerOrder.length
-      this.currentTurn = this.playerOrder[nextIndex]
+      this.advanceToNextConnectedPlayer()
 
       this.room.broadcast(
         JSON.stringify({
@@ -190,7 +213,10 @@ export default class Server implements Party.Server {
   startGame() {
     if (this.gameStarted) return
     this.gameStarted = true
-    this.currentTurn = this.playerOrder[0]
+
+    this.currentTurn =
+      this.playerOrder.find((id) => this.players[id]?.connected) ||
+      this.playerOrder[0]
 
     this.bag = shuffleBag(buildBag())
 

--- a/party/index.ts
+++ b/party/index.ts
@@ -108,9 +108,12 @@ export default class Server implements Party.Server {
       return
     }
 
+    if (!this.players[sender.id] || typeof msg !== "object" || msg === null)
+      return
+
     const action = msg as { type?: string; placements?: unknown }
 
-    if (!this.players[sender.id] || !action.type) return
+    if (typeof action.type !== "string") return
 
     if (action.type === "READY" || action.type === "UNREADY") {
       this.handleReadyToggle(sender, action.type)

--- a/party/index.ts
+++ b/party/index.ts
@@ -101,6 +101,7 @@ export default class Server implements Party.Server {
         JSON.stringify({
           type: "GAME_START",
           roomId: this.room.id,
+          currentTurn: this.currentTurn,
         })
       )
     }
@@ -168,7 +169,7 @@ export default class Server implements Party.Server {
     }
 
     if (msg.type === "SUBMIT_TURN") {
-      if (sender.id === this.currentTurn) return
+      if (sender.id !== this.currentTurn) return
 
       this.refillRack(sender.id)
 

--- a/party/index.ts
+++ b/party/index.ts
@@ -13,7 +13,12 @@ import {
   advanceToNextConnectedPlayer,
   findFirstConnectedPlayer,
 } from "./lib/turns"
-import { toPublicPlayer, type Player, type Tile } from "./lib/types"
+import {
+  isPlacement,
+  toPublicPlayer,
+  type Player,
+  type Tile,
+} from "./lib/types"
 
 export default class Server implements Party.Server {
   players: Record<string, Player> = {}
@@ -103,60 +108,14 @@ export default class Server implements Party.Server {
       return
     }
 
-    if (!this.players[sender.id]) return
-    if (typeof msg !== "object" || msg === null || !("type" in msg)) return
+    const action = msg as { type?: string; placements?: unknown }
 
-    if (msg.type === "READY" || msg.type === "UNREADY") {
-      this.players[sender.id].ready = msg.type === "READY"
-      const list = Object.values(this.players)
-      const allReady = list.length >= MIN_PLAYERS && list.every((p) => p.ready)
-      if (allReady) {
-        this.startGame()
-      } else {
-        broadcastRoomState(this.room, list.map(toPublicPlayer))
-      }
-    }
+    if (!this.players[sender.id] || !action.type) return
 
-    if (msg.type === "SUBMIT_TURN") {
-      if (sender.id !== this.currentTurn) return
-
-      const player = this.players[sender.id]
-      const raw = (msg as Record<string, unknown>).placements
-
-      if (Array.isArray(raw)) {
-        const indices = [
-          ...new Set(
-            raw
-              .filter(
-                (p): p is { rackIndex: number } =>
-                  p !== null &&
-                  typeof p === "object" &&
-                  "rackIndex" in p &&
-                  typeof (p as Record<string, unknown>).rackIndex === "number"
-              )
-              .map((p) => p.rackIndex)
-          ),
-        ].sort((a, b) => b - a)
-
-        for (const index of indices) {
-          if (index >= 0 && index < player.rack.length) {
-            player.rack.splice(index, 1)
-          }
-        }
-      }
-
-      const { rack, bag } = refillRack(player.rack, this.bag)
-      player.rack = rack
-      this.bag = bag
-      const conn = this.room.getConnection(sender.id)
-      if (conn) sendRack(conn, player.rack)
-
-      this.currentTurn = advanceToNextConnectedPlayer(
-        this.playerOrder,
-        this.players,
-        this.currentTurn
-      )
-      broadcastTurnChange(this.room, this.currentTurn)
+    if (action.type === "READY" || action.type === "UNREADY") {
+      this.handleReadyToggle(sender, action.type)
+    } else if (action.type === "SUBMIT_TURN") {
+      this.handleSubmitTurn(sender, action)
     }
   }
 
@@ -177,5 +136,68 @@ export default class Server implements Party.Server {
     }
 
     broadcastGameStart(this.room, this.currentTurn)
+  }
+
+  private handleSubmitTurn(
+    sender: Party.Connection,
+    msg: { placements?: unknown }
+  ) {
+    // Only the active player is allowed to submit a turn
+    if (sender.id !== this.currentTurn) return
+
+    const player = this.players[sender.id]
+    const indices = this.getValidatedRackIndices(msg.placements)
+
+    // Removing tiles from the end of the array first prevents index shifts
+    // from invalidating remaining indices in the sequence.
+    this.removeTilesFromRack(player, indices)
+
+    const { rack, bag } = refillRack(player.rack, this.bag)
+    player.rack = rack
+    this.bag = bag
+
+    this.room
+      .getConnection(sender.id)
+      ?.send(JSON.stringify({ type: "RACK", rack }))
+
+    this.currentTurn = advanceToNextConnectedPlayer(
+      this.playerOrder,
+      this.players,
+      this.currentTurn
+    )
+    broadcastTurnChange(this.room, this.currentTurn)
+  }
+
+  private getValidatedRackIndices(placements: unknown): number[] {
+    if (!Array.isArray(placements)) return []
+
+    // Deduplication is necessary because a player might accidentally
+    // submit the same rack index twice in a single turn.
+    return [
+      ...new Set(placements.filter(isPlacement).map((p) => p.rackIndex)),
+    ].sort((a, b) => b - a)
+  }
+
+  private handleReadyToggle(
+    sender: Party.Connection,
+    type: "READY" | "UNREADY"
+  ) {
+    this.players[sender.id].ready = type === "READY"
+    const list = Object.values(this.players)
+    const allReady = list.length >= MIN_PLAYERS && list.every((p) => p.ready)
+
+    if (allReady) {
+      this.startGame()
+    } else {
+      broadcastRoomState(this.room, list.map(toPublicPlayer))
+    }
+  }
+
+  private removeTilesFromRack(player: Player, indices: number[]) {
+    for (const index of indices) {
+      if (index >= 0 && index < player.rack.length) {
+        player.rack.splice(index, 1)
+      }
+    }
   }
 }

--- a/party/index.ts
+++ b/party/index.ts
@@ -1,57 +1,19 @@
 import type * as Party from "partykit/server"
+import { MAX_PLAYERS, MIN_PLAYERS, RACK_SIZE } from "./constants"
+import { buildBag, drawTiles, refillRack, shuffleBag } from "./lib/bag"
 import {
-  MAX_PLAYERS,
-  MIN_PLAYERS,
-  RACK_SIZE,
-  TILE_DISTRIBUTION,
-} from "./constants"
-
-interface Player {
-  id: string
-  ready: boolean
-  rack: Tile[]
-  connected: boolean
-}
-
-export interface Tile {
-  letter: string
-  points: number
-}
-
-function buildBag(): Tile[] {
-  const bag: Tile[] = []
-  for (const { letter, points, count } of TILE_DISTRIBUTION) {
-    for (let i = 0; i < count; i++) {
-      bag.push({ letter, points })
-    }
-  }
-  return bag
-}
-
-function shuffleBag(bag: Tile[]): Tile[] {
-  const shuffled = [...bag]
-  const rand = new Uint32Array(1)
-  for (let i = shuffled.length - 1; i > 0; i--) {
-    crypto.getRandomValues(rand)
-    const j = rand[0] % (i + 1)
-    ;[shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]]
-  }
-  return shuffled
-}
-
-function drawTiles(
-  bag: Tile[],
-  count: number
-): { drawn: Tile[]; remaining: Tile[] } {
-  const remaining = [...bag]
-  const drawn = remaining.splice(0, count)
-  return { drawn, remaining }
-}
-
-function toPublicPlayer(p: Player): Omit<Player, "rack"> {
-  const { rack: _, ...pub } = p
-  return pub
-}
+  broadcastGameStart,
+  broadcastRoomState,
+  broadcastTurnChange,
+  sendGameStart,
+  sendRack,
+  sendRoomFull,
+} from "./lib/messages"
+import {
+  advanceToNextConnectedPlayer,
+  findFirstConnectedPlayer,
+} from "./lib/turns"
+import { toPublicPlayer, type Player, type Tile } from "./lib/types"
 
 export default class Server implements Party.Server {
   players: Record<string, Player> = {}
@@ -62,40 +24,16 @@ export default class Server implements Party.Server {
 
   constructor(readonly room: Party.Room) {}
 
-  advanceToNextConnectedPlayer() {
-    const len = this.playerOrder.length
-    if (len === 0) {
-      this.currentTurn = null
-      return
-    }
-    const start = this.currentTurn
-      ? this.playerOrder.indexOf(this.currentTurn)
-      : -1
-    for (let i = 1; i <= len; i++) {
-      const candidate = this.playerOrder[(start + i) % len]
-      const p = this.players[candidate]
-      if (p && p.connected) {
-        this.currentTurn = candidate
-        return
-      }
-    }
-    this.currentTurn = null
-  }
-
   onConnect(conn: Party.Connection) {
     const isReconnect = !!this.players[conn.id]
+
     if (!isReconnect) {
       if (this.gameStarted || Object.keys(this.players).length >= MAX_PLAYERS) {
-        conn.send(JSON.stringify({ type: "ROOM_FULL" }))
+        sendRoomFull(conn)
         conn.close()
         return
       }
       this.playerOrder.push(conn.id)
-    }
-
-    const existing = this.players[conn.id]
-
-    if (!existing) {
       this.players[conn.id] = {
         id: conn.id,
         ready: false,
@@ -107,67 +45,43 @@ export default class Server implements Party.Server {
     const player = this.players[conn.id]
     player.connected = true
 
-    if (player.rack.length > 0) {
-      conn.send(
-        JSON.stringify({
-          type: "RACK_STATE",
-          tiles: player.rack,
-        })
-      )
-    }
+    if (player.rack.length > 0) sendRack(conn, player.rack)
 
     if (isReconnect && this.gameStarted) {
-      const turnPlayer = this.currentTurn
-        ? this.players[this.currentTurn]
-        : null
-      if (!turnPlayer || !turnPlayer.connected) {
-        this.advanceToNextConnectedPlayer()
-        this.room.broadcast(
-          JSON.stringify({
-            type: "TURN_CHANGE",
-            currentTurn: this.currentTurn,
-          })
+      if (!this.players[this.currentTurn ?? ""]?.connected) {
+        this.currentTurn = advanceToNextConnectedPlayer(
+          this.playerOrder,
+          this.players,
+          this.currentTurn
         )
+        broadcastTurnChange(this.room, this.currentTurn)
       }
-
-      conn.send(
-        JSON.stringify({
-          type: "GAME_START",
-          roomId: this.room.id,
-          currentTurn: this.currentTurn,
-        })
-      )
+      sendGameStart(conn, this.currentTurn)
     }
 
-    this.room.broadcast(
-      JSON.stringify({
-        type: "ROOM_STATE",
-        players: Object.values(this.players).map(toPublicPlayer),
-      })
+    broadcastRoomState(
+      this.room,
+      Object.values(this.players).map(toPublicPlayer)
     )
   }
 
   onClose(conn: Party.Connection) {
     const player = this.players[conn.id]
+
     if (this.gameStarted) {
       if (player) {
         player.connected = false
-
         if (this.currentTurn === conn.id) {
-          this.advanceToNextConnectedPlayer()
-          this.room.broadcast(
-            JSON.stringify({
-              type: "TURN_CHANGE",
-              currentTurn: this.currentTurn,
-            })
+          this.currentTurn = advanceToNextConnectedPlayer(
+            this.playerOrder,
+            this.players,
+            this.currentTurn
           )
+          broadcastTurnChange(this.room, this.currentTurn)
         }
-
-        this.room.broadcast(
-          JSON.stringify({
-            type: "ROOM_STATE",
-            players: Object.values(this.players).map(toPublicPlayer),
-          })
+        broadcastRoomState(
+          this.room,
+          Object.values(this.players).map(toPublicPlayer)
         )
       }
       return
@@ -175,12 +89,9 @@ export default class Server implements Party.Server {
 
     delete this.players[conn.id]
     this.playerOrder = this.playerOrder.filter((id) => id !== conn.id)
-
-    this.room.broadcast(
-      JSON.stringify({
-        type: "ROOM_STATE",
-        players: Object.values(this.players).map(toPublicPlayer),
-      })
+    broadcastRoomState(
+      this.room,
+      Object.values(this.players).map(toPublicPlayer)
     )
   }
 
@@ -197,19 +108,12 @@ export default class Server implements Party.Server {
 
     if (msg.type === "READY" || msg.type === "UNREADY") {
       this.players[sender.id].ready = msg.type === "READY"
-
       const list = Object.values(this.players)
       const allReady = list.length >= MIN_PLAYERS && list.every((p) => p.ready)
-
       if (allReady) {
         this.startGame()
       } else {
-        this.room.broadcast(
-          JSON.stringify({
-            type: "ROOM_STATE",
-            players: list.map(toPublicPlayer),
-          })
-        )
+        broadcastRoomState(this.room, list.map(toPublicPlayer))
       }
     }
 
@@ -217,34 +121,42 @@ export default class Server implements Party.Server {
       if (sender.id !== this.currentTurn) return
 
       const player = this.players[sender.id]
-      const placements = (msg as Record<string, unknown>).placements
+      const raw = (msg as Record<string, unknown>).placements
 
-      if (Array.isArray(placements)) {
-        const indicesToRemove = placements
-          .map((p) => p.rackIndex)
-          .filter((i) => typeof i === "number")
-          .sort((a: number, b: number) => b - a)
+      if (Array.isArray(raw)) {
+        const indices = [
+          ...new Set(
+            raw
+              .filter(
+                (p): p is { rackIndex: number } =>
+                  p !== null &&
+                  typeof p === "object" &&
+                  "rackIndex" in p &&
+                  typeof (p as Record<string, unknown>).rackIndex === "number"
+              )
+              .map((p) => p.rackIndex)
+          ),
+        ].sort((a, b) => b - a)
 
-        // Ensure we remove duplicates to prevent accidental shifting errors
-        const uniqueIndices = [...new Set(indicesToRemove)]
-
-        for (const index of uniqueIndices) {
+        for (const index of indices) {
           if (index >= 0 && index < player.rack.length) {
             player.rack.splice(index, 1)
           }
         }
       }
 
-      this.refillRack(sender.id)
-      this.advanceToNextConnectedPlayer()
+      const { rack, bag } = refillRack(player.rack, this.bag)
+      player.rack = rack
+      this.bag = bag
+      const conn = this.room.getConnection(sender.id)
+      if (conn) sendRack(conn, player.rack)
 
-      this.room.broadcast(
-        JSON.stringify({
-          type: "TURN_CHANGE",
-          currentTurn: this.currentTurn,
-        })
+      this.currentTurn = advanceToNextConnectedPlayer(
+        this.playerOrder,
+        this.players,
+        this.currentTurn
       )
-      return
+      broadcastTurnChange(this.room, this.currentTurn)
     }
   }
 
@@ -252,51 +164,18 @@ export default class Server implements Party.Server {
     if (this.gameStarted) return
     this.gameStarted = true
 
-    const fallbackId = this.playerOrder[0]
-    this.currentTurn =
-      this.playerOrder.find((id) => this.players[id]?.connected) ||
-      (this.players[fallbackId]?.connected ? fallbackId : null)
-
+    this.currentTurn = findFirstConnectedPlayer(this.playerOrder, this.players)
     this.bag = shuffleBag(buildBag())
 
     for (const id in this.players) {
       const player = this.players[id]
-
       const { drawn, remaining } = drawTiles(this.bag, RACK_SIZE)
       this.bag = remaining
       player.rack = drawn
-
-      this.room
-        .getConnection(id)
-        ?.send(JSON.stringify({ type: "RACK_STATE", tiles: drawn }))
+      const conn = this.room.getConnection(id)
+      if (conn) sendRack(conn, drawn)
     }
 
-    this.room.broadcast(
-      JSON.stringify({
-        type: "GAME_START",
-        roomId: this.room.id,
-        currentTurn: this.currentTurn,
-      })
-    )
-  }
-
-  refillRack(connId: string) {
-    const player = this.players[connId]
-    if (!player) return
-
-    const needed = RACK_SIZE - player.rack.length
-    if (needed <= 0 || this.bag.length === 0) return
-
-    const { drawn, remaining } = drawTiles(
-      this.bag,
-      Math.min(needed, this.bag.length)
-    )
-
-    this.bag = remaining
-    player.rack.push(...drawn)
-
-    this.room
-      .getConnection(connId)
-      ?.send(JSON.stringify({ type: "RACK_STATE", tiles: player.rack }))
+    broadcastGameStart(this.room, this.currentTurn)
   }
 }

--- a/party/index.ts
+++ b/party/index.ts
@@ -58,14 +58,19 @@ export default class Server implements Party.Server {
   bag: Tile[] = []
   gameStarted = false
   playerOrder: string[] = []
-  currentTurn: string = ""
+  currentTurn: string | null = null
 
   constructor(readonly room: Party.Room) {}
 
   advanceToNextConnectedPlayer() {
     const len = this.playerOrder.length
-    if (len === 0) return
-    const start = this.playerOrder.indexOf(this.currentTurn)
+    if (len === 0) {
+      this.currentTurn = null
+      return
+    }
+    const start = this.currentTurn
+      ? this.playerOrder.indexOf(this.currentTurn)
+      : -1
     for (let i = 1; i <= len; i++) {
       const candidate = this.playerOrder[(start + i) % len]
       const p = this.players[candidate]
@@ -74,6 +79,7 @@ export default class Server implements Party.Server {
         return
       }
     }
+    this.currentTurn = null
   }
 
   onConnect(conn: Party.Connection) {
@@ -111,6 +117,19 @@ export default class Server implements Party.Server {
     }
 
     if (isReconnect && this.gameStarted) {
+      const turnPlayer = this.currentTurn
+        ? this.players[this.currentTurn]
+        : null
+      if (!turnPlayer || !turnPlayer.connected) {
+        this.advanceToNextConnectedPlayer()
+        this.room.broadcast(
+          JSON.stringify({
+            type: "TURN_CHANGE",
+            currentTurn: this.currentTurn,
+          })
+        )
+      }
+
       conn.send(
         JSON.stringify({
           type: "GAME_START",
@@ -197,6 +216,25 @@ export default class Server implements Party.Server {
     if (msg.type === "SUBMIT_TURN") {
       if (sender.id !== this.currentTurn) return
 
+      const player = this.players[sender.id]
+      const placements = (msg as Record<string, unknown>).placements
+
+      if (Array.isArray(placements)) {
+        const indicesToRemove = placements
+          .map((p) => p.rackIndex)
+          .filter((i) => typeof i === "number")
+          .sort((a: number, b: number) => b - a)
+
+        // Ensure we remove duplicates to prevent accidental shifting errors
+        const uniqueIndices = [...new Set(indicesToRemove)]
+
+        for (const index of uniqueIndices) {
+          if (index >= 0 && index < player.rack.length) {
+            player.rack.splice(index, 1)
+          }
+        }
+      }
+
       this.refillRack(sender.id)
       this.advanceToNextConnectedPlayer()
 
@@ -214,9 +252,10 @@ export default class Server implements Party.Server {
     if (this.gameStarted) return
     this.gameStarted = true
 
+    const fallbackId = this.playerOrder[0]
     this.currentTurn =
       this.playerOrder.find((id) => this.players[id]?.connected) ||
-      this.playerOrder[0]
+      (this.players[fallbackId]?.connected ? fallbackId : null)
 
     this.bag = shuffleBag(buildBag())
 
@@ -233,7 +272,11 @@ export default class Server implements Party.Server {
     }
 
     this.room.broadcast(
-      JSON.stringify({ type: "GAME_START", currentTurn: this.currentTurn })
+      JSON.stringify({
+        type: "GAME_START",
+        roomId: this.room.id,
+        currentTurn: this.currentTurn,
+      })
     )
   }
 

--- a/party/lib/bag.ts
+++ b/party/lib/bag.ts
@@ -1,0 +1,42 @@
+import { RACK_SIZE, TILE_DISTRIBUTION } from "../constants"
+import { Tile } from "./types"
+
+export function buildBag(): Tile[] {
+  const bag: Tile[] = []
+  for (const { letter, points, count } of TILE_DISTRIBUTION) {
+    for (let i = 0; i < count; i++) {
+      bag.push({ letter, points })
+    }
+  }
+  return bag
+}
+
+export function shuffleBag(bag: Tile[]): Tile[] {
+  const shuffled = [...bag]
+  const rand = new Uint32Array(1)
+  for (let i = shuffled.length - 1; i > 0; i--) {
+    crypto.getRandomValues(rand)
+    const j = rand[0] % (i + 1)
+    ;[shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]]
+  }
+  return shuffled
+}
+
+export function drawTiles(
+  bag: Tile[],
+  count: number
+): { drawn: Tile[]; remaining: Tile[] } {
+  const remaining = [...bag]
+  const drawn = remaining.splice(0, Math.min(count, remaining.length))
+  return { drawn, remaining }
+}
+
+export function refillRack(
+  rack: Tile[],
+  bag: Tile[]
+): { rack: Tile[]; bag: Tile[] } {
+  const needed = RACK_SIZE - rack.length
+  if (needed <= 0 || bag.length === 0) return { rack, bag }
+  const { drawn, remaining } = drawTiles(bag, needed)
+  return { rack: [...rack, ...drawn], bag: remaining }
+}

--- a/party/lib/messages.ts
+++ b/party/lib/messages.ts
@@ -1,0 +1,35 @@
+import type * as Party from "partykit/server"
+import type { PublicPlayer, Tile } from "./types"
+
+export function broadcastRoomState(room: Party.Room, players: PublicPlayer[]) {
+  room.broadcast(JSON.stringify({ type: "ROOM_STATE", players }))
+}
+
+export function broadcastTurnChange(
+  room: Party.Room,
+  currentTurn: string | null
+) {
+  room.broadcast(JSON.stringify({ type: "TURN_CHANGE", currentTurn }))
+}
+
+export function broadcastGameStart(
+  room: Party.Room,
+  currentTurn: string | null
+) {
+  room.broadcast(JSON.stringify({ type: "GAME_START", currentTurn }))
+}
+
+export function sendRack(conn: Party.Connection, tiles: Tile[]) {
+  conn.send(JSON.stringify({ type: "RACK_STATE", tiles }))
+}
+
+export function sendRoomFull(conn: Party.Connection) {
+  conn.send(JSON.stringify({ type: "ROOM_FULL" }))
+}
+
+export function sendGameStart(
+  conn: Party.Connection,
+  currentTurn: string | null
+) {
+  conn.send(JSON.stringify({ type: "GAME_START", currentTurn }))
+}

--- a/party/lib/turns.ts
+++ b/party/lib/turns.ts
@@ -1,0 +1,23 @@
+import { Player } from "./types"
+
+export function findFirstConnectedPlayer(
+  playerOrder: string[],
+  players: Record<string, Player>
+): string | null {
+  return playerOrder.find((id) => players[id]?.connected) ?? null
+}
+
+export function advanceToNextConnectedPlayer(
+  playerOrder: string[],
+  players: Record<string, Player>,
+  currentTurn: string | null
+): string | null {
+  const len = playerOrder.length
+  if (len === 0) return null
+  const start = currentTurn ? playerOrder.indexOf(currentTurn) : -1
+  for (let i = 1; i <= len; i++) {
+    const candidate = playerOrder[(start + i) % len]
+    if (players[candidate]?.connected) return candidate
+  }
+  return null
+}

--- a/party/lib/types.ts
+++ b/party/lib/types.ts
@@ -16,3 +16,17 @@ export function toPublicPlayer(p: Player): PublicPlayer {
   const { rack: _, ...pub } = p
   return pub
 }
+
+export function isPlacement(p: unknown): p is { rackIndex: number } {
+  if (typeof p !== "object" || p === null || !("rackIndex" in p)) {
+    return false
+  }
+
+  const { rackIndex } = p as { rackIndex: unknown }
+
+  return (
+    typeof rackIndex === "number" &&
+    Number.isInteger(rackIndex) &&
+    rackIndex >= 0
+  )
+}

--- a/party/lib/types.ts
+++ b/party/lib/types.ts
@@ -1,0 +1,18 @@
+export interface Tile {
+  letter: string
+  points: number
+}
+
+export interface Player {
+  id: string
+  ready: boolean
+  rack: Tile[]
+  connected: boolean
+}
+
+export type PublicPlayer = Omit<Player, "rack">
+
+export function toPublicPlayer(p: Player): PublicPlayer {
+  const { rack: _, ...pub } = p
+  return pub
+}

--- a/party/types.ts
+++ b/party/types.ts
@@ -1,5 +1,0 @@
-export interface Player {
-  id: string
-  ready: boolean
-}
-export type Players = Record<string, Player>

--- a/src/components/game/Rack.tsx
+++ b/src/components/game/Rack.tsx
@@ -15,7 +15,7 @@ export default function Rack({ tiles, disabled }: RackProps) {
     <div
       ref={setNodeRef}
       className={cn(
-        "@container flex w-auto items-center justify-center gap-1 rounded-xl bg-border px-2 py-2",
+        "@container flex w-full items-center justify-center gap-1 rounded-xl bg-border px-2 py-2",
         !disabled && isOver ? "ring-2 ring-primary/30" : null
       )}
     >

--- a/src/components/game/ScoreBoardItem.tsx
+++ b/src/components/game/ScoreBoardItem.tsx
@@ -4,29 +4,30 @@ import { Item, ItemContent, ItemTitle } from "../ui/item"
 import { Badge } from "../ui/badge"
 import { cn } from "@/lib/utils"
 
-interface PlayerItemProps {
+interface ScoreBoardItemProps {
   player: Player
   isMe: boolean
+  currentTurn?: string
 }
 
-export default function PlayerItem({ player, isMe }: PlayerItemProps) {
-  const { t } = useTranslation("room")
+export default function ScoreBoardItem({
+  player,
+  isMe,
+  currentTurn,
+}: ScoreBoardItemProps) {
+  const { t } = useTranslation("game")
+  const isTurnHolder = player.id === currentTurn
 
   return (
     <Item
-      variant={player.ready ? "muted" : "default"}
-      className={cn("w-auto", isMe ? "ring-2 ring-secondary" : null)}
+      variant={isMe ? "muted" : "default"}
+      className={cn("w-auto", isTurnHolder ? "ring-2 ring-primary" : null)}
     >
       <ItemContent>
         <ItemTitle>
           {player.id}
           {isMe && <Badge variant="outline">{t("labels.you")}</Badge>}
         </ItemTitle>
-      </ItemContent>
-      <ItemContent>
-        <Badge variant={player.ready ? "default" : "secondary"}>
-          {t(player.ready ? "player.ready" : "player.notReady")}
-        </Badge>
       </ItemContent>
     </Item>
   )

--- a/src/components/game/ScoreBoardList.tsx
+++ b/src/components/game/ScoreBoardList.tsx
@@ -1,0 +1,30 @@
+import type { Player } from "@/types/room"
+import ScoreBoardItem from "./ScoreBoardItem"
+import { getClientId } from "@/lib/clientId"
+
+interface ScoreBoardItemProps {
+  players: Player[]
+  currentTurn?: string
+}
+
+export default function ScoreBoardList({
+  players,
+  currentTurn,
+}: ScoreBoardItemProps) {
+  const myId = getClientId()
+
+  return (
+    <div className="flex w-auto flex-col justify-center gap-1">
+      {players.map((player) => {
+        return (
+          <ScoreBoardItem
+            key={player.id}
+            player={player}
+            isMe={myId === player.id}
+            currentTurn={currentTurn}
+          />
+        )
+      })}
+    </div>
+  )
+}

--- a/src/hooks/game/useGameSession.ts
+++ b/src/hooks/game/useGameSession.ts
@@ -1,5 +1,5 @@
 import { getClientId } from "@/lib/clientId"
-import type { ServerMessage, TileType } from "@/types/room"
+import type { Player, ServerMessage, TileType } from "@/types/room"
 import usePartySocket from "partysocket/react"
 import { useCallback, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
@@ -11,17 +11,26 @@ export function useGameSession(roomId: string) {
   const navigate = useNavigate()
   const [tiles, setTiles] = useState<TileType[]>([])
   const intentionalClose = useRef(false)
+  const myId = getClientId()
+  const [currentTurn, setCurrentTurn] = useState<string>("")
+  const [players, setPlayers] = useState<Player[]>([])
 
   const socket = usePartySocket({
     host: import.meta.env.VITE_PARTYKIT_HOST ?? "localhost:1999",
     room: roomId,
-    id: getClientId(),
+    id: myId,
     onMessage(event) {
       try {
         const msg = JSON.parse(event.data) as ServerMessage
         switch (msg.type) {
           case "RACK_STATE":
             setTiles(msg.tiles)
+            break
+          case "TURN_CHANGE":
+            setCurrentTurn(msg.currentTurn)
+            break
+          case "ROOM_STATE":
+            setPlayers(msg.players)
             break
         }
       } catch {
@@ -50,5 +59,7 @@ export function useGameSession(roomId: string) {
     [socket]
   )
 
-  return { tiles, send }
+  const isMyTurn = currentTurn === myId
+
+  return { tiles, players, currentTurn, isMyTurn, send }
 }

--- a/src/hooks/game/useGameSession.ts
+++ b/src/hooks/game/useGameSession.ts
@@ -32,6 +32,9 @@ export function useGameSession(roomId: string) {
           case "ROOM_STATE":
             setPlayers(msg.players)
             break
+          case "GAME_START":
+            setCurrentTurn(msg.currentTurn)
+            break
         }
       } catch {
         console.log("non-JSON message:", event.data)

--- a/src/locales/en/game.json
+++ b/src/locales/en/game.json
@@ -10,5 +10,8 @@
         "description": "The connection was interrupted. You have been returned to the home screen."
       }
     }
+  },
+  "labels": {
+    "you": "You"
   }
 }

--- a/src/pages/Game.tsx
+++ b/src/pages/Game.tsx
@@ -17,7 +17,7 @@ import {
   type DragStartEvent,
 } from "@dnd-kit/core"
 import { Check, Trash } from "lucide-react"
-import { useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import { useParams } from "react-router"
 
 function GameSessionView({ roomId }: { roomId: string }) {
@@ -33,11 +33,20 @@ function GameSessionView({ roomId }: { roomId: string }) {
   } = useTileAssignment(tiles)
   const [activeTile, setActiveTile] = useState<TileType | null>(null)
 
+  const isSubmittingRef = useRef(false)
+
   const sensors = useSensors(
     useSensor(PointerSensor, {
       activationConstraint: { distance: 8 },
     })
   )
+
+  useEffect(() => {
+    if (!isMyTurn && isSubmittingRef.current) {
+      returnAll()
+      isSubmittingRef.current = false
+    }
+  }, [isMyTurn, returnAll])
 
   const handleDragStart = (event: DragStartEvent) => {
     const activeData = event.active.data.current as
@@ -75,8 +84,8 @@ function GameSessionView({ roomId }: { roomId: string }) {
   }
 
   const handleSubmitTurn = () => {
+    isSubmittingRef.current = true
     send({ type: "SUBMIT_TURN" })
-    returnAll()
   }
 
   return (

--- a/src/pages/Game.tsx
+++ b/src/pages/Game.tsx
@@ -42,11 +42,11 @@ function GameSessionView({ roomId }: { roomId: string }) {
   )
 
   useEffect(() => {
-    if (!isMyTurn && isSubmittingRef.current) {
+    if (isSubmittingRef.current) {
       returnAll()
       isSubmittingRef.current = false
     }
-  }, [isMyTurn, returnAll])
+  }, [currentTurn, returnAll])
 
   const handleDragStart = (event: DragStartEvent) => {
     const activeData = event.active.data.current as
@@ -114,6 +114,7 @@ function GameSessionView({ roomId }: { roomId: string }) {
             variant="secondary"
             disabled={!isMyTurn || Object.keys(assignments).length === 0}
             onClick={handleSubmitTurn}
+            aria-label="Submit turn"
           >
             <Check />
           </Button>

--- a/src/pages/Game.tsx
+++ b/src/pages/Game.tsx
@@ -1,5 +1,6 @@
 import Board from "@/components/game/Board"
 import Rack from "@/components/game/Rack"
+import ScoreBoardList from "@/components/game/ScoreBoardList"
 import Tile from "@/components/game/Tile"
 import RoomLayout from "@/components/room/RoomLayout"
 import { Button } from "@/components/ui/button"
@@ -15,12 +16,12 @@ import {
   type DragEndEvent,
   type DragStartEvent,
 } from "@dnd-kit/core"
-import { Trash } from "lucide-react"
+import { Check, Trash } from "lucide-react"
 import { useState } from "react"
 import { useParams } from "react-router"
 
 function GameSessionView({ roomId }: { roomId: string }) {
-  const { tiles } = useGameSession(roomId)
+  const { tiles, players, currentTurn, isMyTurn, send } = useGameSession(roomId)
   const {
     rack,
     assignTile,
@@ -73,6 +74,11 @@ function GameSessionView({ roomId }: { roomId: string }) {
     setActiveTile(null)
   }
 
+  const handleSubmitTurn = () => {
+    send({ type: "SUBMIT_TURN" })
+    returnAll()
+  }
+
   return (
     <DndContext
       sensors={sensors}
@@ -81,18 +87,28 @@ function GameSessionView({ roomId }: { roomId: string }) {
       onDragCancel={handleDragCancel}
     >
       <RoomLayout roomId={roomId}>
+        <ScoreBoardList players={players} currentTurn={currentTurn} />
         <div className="@container-[size] flex min-h-0 w-full flex-1 items-center justify-center">
           <Board boardTiles={boardTiles} assignments={assignments} />
         </div>
-        <Button
-          onClick={returnAll}
-          variant="destructive"
-          disabled={Object.keys(assignments).length === 0}
-          aria-label="Clear all placements"
-        >
-          <Trash />
-        </Button>
-        <Rack tiles={rack} />
+        <div className="flex w-full items-center gap-2">
+          <Button
+            onClick={returnAll}
+            variant="destructive"
+            disabled={Object.keys(assignments).length === 0}
+            aria-label="Clear all placements"
+          >
+            <Trash />
+          </Button>
+          <Rack tiles={rack} disabled={!isMyTurn} />
+          <Button
+            variant="secondary"
+            disabled={!isMyTurn || Object.keys(assignments).length === 0}
+            onClick={handleSubmitTurn}
+          >
+            <Check />
+          </Button>
+        </div>
       </RoomLayout>
 
       <DragOverlay dropAnimation={null}>

--- a/src/types/room.ts
+++ b/src/types/room.ts
@@ -2,9 +2,13 @@ export type ServerMessage =
   | { type: "ROOM_STATE"; players: Player[] }
   | { type: "ROOM_FULL" }
   | { type: "GAME_START"; currentTurn: string }
+  | { type: "TURN_CHANGE"; currentTurn: string }
   | { type: "RACK_STATE"; tiles: TileType[] }
 
-export type ClientMessage = { type: "READY" } | { type: "UNREADY" }
+export type ClientMessage =
+  | { type: "READY" }
+  | { type: "UNREADY" }
+  | { type: "SUBMIT_TURN" }
 
 export interface Player {
   id: string

--- a/src/types/room.ts
+++ b/src/types/room.ts
@@ -8,7 +8,10 @@ export type ServerMessage =
 export type ClientMessage =
   | { type: "READY" }
   | { type: "UNREADY" }
-  | { type: "SUBMIT_TURN" }
+  | {
+      type: "SUBMIT_TURN"
+      placements: { rackIndex: number; cellIndex: number }[]
+    }
 
 export interface Player {
   id: string

--- a/src/types/room.ts
+++ b/src/types/room.ts
@@ -21,3 +21,5 @@ export interface TileType {
 }
 
 export type TileAssignments = Partial<Record<number, number>>
+
+export type PlayerStatus = "ready" | "not-ready" | "your-turn" | "their-turn"

--- a/src/types/room.ts
+++ b/src/types/room.ts
@@ -1,7 +1,7 @@
 export type ServerMessage =
   | { type: "ROOM_STATE"; players: Player[] }
   | { type: "ROOM_FULL" }
-  | { type: "GAME_START"; currentTurn: string }
+  | { type: "GAME_START"; roomId: string; currentTurn: string }
   | { type: "TURN_CHANGE"; currentTurn: string }
   | { type: "RACK_STATE"; tiles: TileType[] }
 


### PR DESCRIPTION
Adds turn-based game logic and UI components to support sequential player turns. Players are now tracked in a fixed order, the server broadcasts turn changes, and clients can see whose turn it is and submit their moves. The rack and submit button are disabled for players waiting for their turn.

## Changes

- Added `playerOrder` and `currentTurn` state to `Server` to track turn sequence
- Modified connection handler to append new players to `playerOrder` for deterministic ordering
- Updated `READY`/`UNREADY` message handler to be more concise without changing behavior
- Added `SUBMIT_TURN` message type that advances to the next player and refills the current player's rack
- Updated `GAME_START` broadcasts to include `currentTurn` so clients know who plays first
- Created `ScoreBoardItem` component to display individual player status with visual indicator for turn holder
- Created `ScoreBoardList` component to render all players and pass through current turn state
- Updated `PlayerItem` variant logic to use ring highlight instead of variant change for highlighting own player
- Enhanced `Rack` component to accept `disabled` prop and changed width from `w-auto` to `w-full`
- Modified `useGameSession` hook to track `currentTurn` and `players` from server messages and expose `isMyTurn` flag
- Added turn change and game start message handlers in `useGameSession` to update UI state
- Updated `Game` page layout to display `ScoreBoardList`, disable rack and submit button when not player's turn, and add submit button to end turn
- Added `TURN_CHANGE` message type to server message union
- Added `SUBMIT_TURN` message type to client message union
- Added `you` label translation for identifying the current player in the UI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- **party/index.ts** - Added server-side turn tracking via `playerOrder: string[]` and `currentTurn: string | null`; new (non-reconnect) connections append to `playerOrder`; uses helpers to find/advance next connected player; READY/UNREADY handling refactored to boolean toggles; `startGame()` initializes `currentTurn` from `playerOrder`, shuffles/builds bag, deals racks and sends per-player racks; GAME_START broadcasts include `currentTurn`; on disconnect/reconnect advances turn if holder is disconnected, removes departed IDs, and broadcasts `TURN_CHANGE`; implemented `SUBMIT_TURN` handling that rejects non-current players, validates/dedups submitted rack indices, removes submitted tiles, refills the submitting player's rack from the bag, advances to the next connected player, and emits `TURN_CHANGE`.
- **party/lib/turns.ts** - New helpers: `findFirstConnectedPlayer(playerOrder, players)` and `advanceToNextConnectedPlayer(playerOrder, players, currentTurn)` for deterministic turn navigation among connected players.
- **party/lib/bag.ts** - New deterministic bag utilities: `buildBag()`, `shuffleBag(bag)`, `drawTiles(bag, count)`, and `refillRack(rack, bag)` to build/shuffle/draw/refill tiles.
- **party/lib/messages.ts** - New message helper functions to broadcast/send typed room and connection messages: `broadcastRoomState`, `broadcastTurnChange`, `broadcastGameStart`, `sendRack`, `sendRoomFull`, `sendGameStart`.
- **party/lib/types.ts** - New domain types: `Tile`, `Player` (with `rack` and `connected`), `PublicPlayer` and `toPublicPlayer()` to expose privacy-preserving player views; `isPlacement` type guard added; `party/index` now imports Tile from here instead of exporting its own Tile type.
- **party/types.ts** - Removed previous exported `Player` and `Players` types (moved to `party/lib/types.ts`).
- **src/components/game/ScoreBoardItem.tsx** - New component rendering a player entry with a localized "you" badge for the local player and a visual ring highlight when matching `currentTurn`.
- **src/components/game/ScoreBoardList.tsx** - New component rendering a vertical list of players, determining `isMe` via `getClientId()` and forwarding `currentTurn` to `ScoreBoardItem`.
- **src/components/game/Rack.tsx** - Rack container sizing changed from `w-auto` to `w-full`; `Rack` accepts a `disabled` prop to disable interactions when not the player's turn.
- **src/components/room/PlayerItem.tsx** - `Item` variant now derived solely from `player.ready` (`"muted"` when ready, otherwise `"default"`); conditional `ring-2 ring-secondary` highlight when `isMe` added; `cn` utility imported.
- **src/hooks/game/useGameSession.ts** - Hook now derives `myId` via `getClientId()`, sets PartySocket connection id to `myId`, tracks `players` and `currentTurn`, handles `TURN_CHANGE`, `ROOM_STATE`, and `GAME_START` (in addition to `RACK_STATE`), and returns `{ tiles, players, currentTurn, isMyTurn, send }` where `isMyTurn = currentTurn === myId`.
- **src/pages/Game.tsx** - Displays `ScoreBoardList`; disables `Rack` and submit/clear buttons when not the player's turn (or when no assignments); adds a submit-turn flow that sends `{ type: "SUBMIT_TURN" }`, uses `isSubmittingRef` to detect mid-submit turn changes and call `returnAll()`, and updates icons to `Check`/`Trash`.
- **src/locales/en/game.json** - Added `labels.you` translation ("You") to identify the local player.
- **src/types/room.ts** - `ServerMessage` updated: `"GAME_START"` now includes `roomId` and `currentTurn`; added `{ type: "TURN_CHANGE"; currentTurn: string | null }`; `ClientMessage` extended with `{ type: "SUBMIT_TURN"; placements: { rackIndex: number; cellIndex: number }[] }`; added `PlayerStatus` type (`"ready" | "not-ready" | "your-turn" | "their-turn"`).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ImDarkly/mova/pull/51?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->