### PR TITLE
Refactor board and tile types to use CellCoord and row/col system

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,14 +1,14 @@
-import js from '@eslint/js'
-import globals from 'globals'
-import reactHooks from 'eslint-plugin-react-hooks'
-import reactRefresh from 'eslint-plugin-react-refresh'
-import tseslint from 'typescript-eslint'
-import { defineConfig, globalIgnores } from 'eslint/config'
+import js from "@eslint/js"
+import globals from "globals"
+import reactHooks from "eslint-plugin-react-hooks"
+import reactRefresh from "eslint-plugin-react-refresh"
+import tseslint from "typescript-eslint"
+import { defineConfig, globalIgnores } from "eslint/config"
 
 export default defineConfig([
-  globalIgnores(['dist']),
+  globalIgnores(["dist"]),
   {
-    files: ['**/*.{ts,tsx}'],
+    files: ["**/*.{ts,tsx}"],
     extends: [
       js.configs.recommended,
       tseslint.configs.recommended,
@@ -18,6 +18,12 @@ export default defineConfig([
     languageOptions: {
       ecmaVersion: 2020,
       globals: globals.browser,
+    },
+    rules: {
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        { varsIgnorePattern: "^_", argsIgnorePattern: "^_" },
+      ],
     },
   },
 ])

--- a/party/constants.ts
+++ b/party/constants.ts
@@ -37,3 +37,5 @@ export const TILE_DISTRIBUTION: {
 ]
 
 export const RACK_SIZE = 7
+
+export const BOARD_SIZE = 15

--- a/party/index.ts
+++ b/party/index.ts
@@ -2,12 +2,14 @@ import type * as Party from "partykit/server"
 import { BOARD_SIZE, MAX_PLAYERS, MIN_PLAYERS, RACK_SIZE } from "./constants"
 import { buildBag, drawTiles, refillRack, shuffleBag } from "./lib/bag"
 import {
+  broadcastBoardState,
   broadcastGameStart,
   broadcastRoomState,
   broadcastTurnChange,
   sendGameStart,
   sendRack,
   sendRoomFull,
+  sendSubmitError,
 } from "./lib/messages"
 import {
   advanceToNextConnectedPlayer,
@@ -19,6 +21,7 @@ import {
   type Player,
   type Tile,
 } from "./lib/types"
+import { validatePlacements } from "./lib/validation"
 
 export default class Server implements Party.Server {
   players: Record<string, Player> = {}
@@ -65,6 +68,7 @@ export default class Server implements Party.Server {
         broadcastTurnChange(this.room, this.currentTurn)
       }
       sendGameStart(conn, this.currentTurn)
+      broadcastBoardState(this.room, this.board)
     }
 
     broadcastRoomState(
@@ -152,6 +156,20 @@ export default class Server implements Party.Server {
     if (sender.id !== this.currentTurn) return
 
     const player = this.players[sender.id]
+    const placements = Array.isArray(msg.placements)
+      ? msg.placements.filter(isPlacement)
+      : []
+
+    const result = validatePlacements(placements, this.board)
+    if (!result.valid) {
+      sendSubmitError(sender, result.error)
+      return
+    }
+
+    for (const { row, col, rackIndex } of placements) {
+      this.board[row][col] = player.rack[rackIndex]
+    }
+
     const indices = this.getValidatedRackIndices(msg.placements)
 
     // Removing tiles from the end of the array first prevents index shifts
@@ -164,7 +182,9 @@ export default class Server implements Party.Server {
 
     this.room
       .getConnection(sender.id)
-      ?.send(JSON.stringify({ type: "RACK", rack }))
+      ?.send(JSON.stringify({ type: "RACK_STATE", tiles: rack }))
+
+    broadcastBoardState(this.room, this.board)
 
     this.currentTurn = advanceToNextConnectedPlayer(
       this.playerOrder,

--- a/party/index.ts
+++ b/party/index.ts
@@ -1,5 +1,5 @@
 import type * as Party from "partykit/server"
-import { MAX_PLAYERS, MIN_PLAYERS, RACK_SIZE } from "./constants"
+import { BOARD_SIZE, MAX_PLAYERS, MIN_PLAYERS, RACK_SIZE } from "./constants"
 import { buildBag, drawTiles, refillRack, shuffleBag } from "./lib/bag"
 import {
   broadcastGameStart,
@@ -26,6 +26,9 @@ export default class Server implements Party.Server {
   gameStarted = false
   playerOrder: string[] = []
   currentTurn: string | null = null
+  board: (Tile | null)[][] = Array.from({ length: BOARD_SIZE }, () =>
+    Array.from({ length: BOARD_SIZE }, () => null)
+  )
 
   constructor(readonly room: Party.Room) {}
 

--- a/party/index.ts
+++ b/party/index.ts
@@ -68,7 +68,7 @@ export default class Server implements Party.Server {
         broadcastTurnChange(this.room, this.currentTurn)
       }
       sendGameStart(conn, this.currentTurn)
-      broadcastBoardState(this.room, this.board)
+      this.sendBoardState(conn, this.board)
     }
 
     broadcastRoomState(
@@ -225,5 +225,9 @@ export default class Server implements Party.Server {
         player.rack.splice(index, 1)
       }
     }
+  }
+
+  private sendBoardState(conn: Party.Connection, board: (Tile | null)[][]) {
+    conn.send(JSON.stringify({ type: "BOARD_STATE", board }))
   }
 }

--- a/party/lib/messages.ts
+++ b/party/lib/messages.ts
@@ -33,3 +33,24 @@ export function sendGameStart(
 ) {
   conn.send(JSON.stringify({ type: "GAME_START", currentTurn }))
 }
+
+export function broadcastBoardState(
+  room: Party.Room,
+  board: (Tile | null)[][]
+) {
+  const flat: Record<string, Tile> = {}
+
+  for (let row = 0; row < board.length; row++) {
+    for (let col = 0; col < board[row].length; col++) {
+      const tile = board[row][col]
+      if (tile !== null) {
+        flat[`${row},${col}`] = tile
+      }
+      room.broadcast(JSON.stringify({ type: "BOARD_STATE", board: flat }))
+    }
+  }
+}
+
+export function sendSubmitError(conn: Party.Connection, error: string) {
+  conn.send(JSON.stringify({ type: "SUBMIT_ERROR", error }))
+}

--- a/party/lib/messages.ts
+++ b/party/lib/messages.ts
@@ -46,9 +46,9 @@ export function broadcastBoardState(
       if (tile !== null) {
         flat[`${row},${col}`] = tile
       }
-      room.broadcast(JSON.stringify({ type: "BOARD_STATE", board: flat }))
     }
   }
+  room.broadcast(JSON.stringify({ type: "BOARD_STATE", board: flat }))
 }
 
 export function sendSubmitError(conn: Party.Connection, error: string) {

--- a/party/lib/messages.ts
+++ b/party/lib/messages.ts
@@ -1,5 +1,6 @@
 import type * as Party from "partykit/server"
 import type { PublicPlayer, Tile } from "./types"
+import type { SubmitErrorCode } from "./validation"
 
 export function broadcastRoomState(room: Party.Room, players: PublicPlayer[]) {
   room.broadcast(JSON.stringify({ type: "ROOM_STATE", players }))
@@ -51,6 +52,9 @@ export function broadcastBoardState(
   room.broadcast(JSON.stringify({ type: "BOARD_STATE", board: flat }))
 }
 
-export function sendSubmitError(conn: Party.Connection, error: string) {
+export function sendSubmitError(
+  conn: Party.Connection,
+  error: SubmitErrorCode
+) {
   conn.send(JSON.stringify({ type: "SUBMIT_ERROR", error }))
 }

--- a/party/lib/types.ts
+++ b/party/lib/types.ts
@@ -18,18 +18,33 @@ export interface CellCoord {
 export type PublicPlayer = Omit<Player, "rack">
 
 export function toPublicPlayer(p: Player): PublicPlayer {
-  const { rack: _, ...pub } = p
+  const { rack: _rack, ...pub } = p
   return pub
 }
 
-export function isPlacement(p: unknown): p is { row: number; col: number } {
-  if (typeof p !== "object" || p === null || !("row" in p) || !("col" in p)) {
+export function isPlacement(
+  p: unknown
+): p is { rackIndex: number; row: number; col: number } {
+  if (
+    typeof p !== "object" ||
+    p === null ||
+    !("row" in p) ||
+    !("col" in p) ||
+    !("rackIndex" in p)
+  ) {
     return false
   }
 
-  const { row, col } = p as { row: unknown; col: unknown }
+  const { row, col, rackIndex } = p as {
+    row: unknown
+    col: unknown
+    rackIndex: unknown
+  }
 
   return (
+    typeof rackIndex === "number" &&
+    Number.isInteger(rackIndex) &&
+    rackIndex >= 0 &&
     typeof row === "number" &&
     Number.isInteger(row) &&
     row >= 0 &&

--- a/party/lib/types.ts
+++ b/party/lib/types.ts
@@ -10,6 +10,11 @@ export interface Player {
   connected: boolean
 }
 
+export interface CellCoord {
+  row: number
+  col: number
+}
+
 export type PublicPlayer = Omit<Player, "rack">
 
 export function toPublicPlayer(p: Player): PublicPlayer {
@@ -17,16 +22,19 @@ export function toPublicPlayer(p: Player): PublicPlayer {
   return pub
 }
 
-export function isPlacement(p: unknown): p is { rackIndex: number } {
-  if (typeof p !== "object" || p === null || !("rackIndex" in p)) {
+export function isPlacement(p: unknown): p is { row: number; col: number } {
+  if (typeof p !== "object" || p === null || !("row" in p) || !("col" in p)) {
     return false
   }
 
-  const { rackIndex } = p as { rackIndex: unknown }
+  const { row, col } = p as { row: unknown; col: unknown }
 
   return (
-    typeof rackIndex === "number" &&
-    Number.isInteger(rackIndex) &&
-    rackIndex >= 0
+    typeof row === "number" &&
+    Number.isInteger(row) &&
+    row >= 0 &&
+    typeof col === "number" &&
+    Number.isInteger(col) &&
+    col >= 0
   )
 }

--- a/party/lib/validation.ts
+++ b/party/lib/validation.ts
@@ -5,7 +5,14 @@ type ValidationResult =
   | { valid: true }
   | {
       valid: false
-      error: "NO_TILES" | "NOT_IN_LINE" | "GAP_NOT_FILLED" | "NOT_CONNECTED"
+      error:
+        | "NO_TILES"
+        | "NOT_IN_LINE"
+        | "GAP_NOT_FILLED"
+        | "NOT_CONNECTED"
+        | "OUT_OF_BOUNDS"
+        | "CELL_OCCUPIED"
+        | "DUPLICATE_COORDINATE"
     }
 export type SubmitErrorCode = Extract<
   ValidationResult,
@@ -17,6 +24,21 @@ export function validatePlacements(
   board: (Tile | null)[][]
 ): ValidationResult {
   if (placements.length === 0) return { valid: false, error: "NO_TILES" }
+
+  const coords = new Set<string>()
+  for (const { row, col } of placements) {
+    if (row < 0 || row >= board.length || col < 0 || col >= board[0].length) {
+      return { valid: false, error: "OUT_OF_BOUNDS" }
+    }
+    if (board[row][col] !== null) {
+      return { valid: false, error: "CELL_OCCUPIED" }
+    }
+    const key = `${row},${col}`
+    if (coords.has(key)) {
+      return { valid: false, error: "DUPLICATE_COORDINATE" }
+    }
+    coords.add(key)
+  }
 
   if (placements.length > 1) {
     const lineResult = isInline(placements, board)

--- a/party/lib/validation.ts
+++ b/party/lib/validation.ts
@@ -1,0 +1,99 @@
+import { Tile } from "./types"
+
+type Placement = { rackIndex: number; row: number; col: number }
+type ValidationResult =
+  | { valid: true }
+  | {
+      valid: false
+      error: "NO_TILES" | "NOT_IN_LINE" | "GAP_NOT_FILLED" | "NOT_CONNECTED"
+    }
+
+export function validatePlacements(
+  placements: Placement[],
+  board: (Tile | null)[][]
+): ValidationResult {
+  if (placements.length === 0) return { valid: false, error: "NO_TILES" }
+
+  if (placements.length > 1) {
+    const lineResult = isInline(placements, board)
+    if (!lineResult.valid) return lineResult
+  }
+
+  return isConnected(placements, board)
+}
+
+function isInline(
+  placements: Placement[],
+  board: (Tile | null)[][]
+): ValidationResult {
+  const rows = placements.map((p) => p.row)
+  const cols = placements.map((p) => p.col)
+
+  const allSameRow = rows.every((r) => r === rows[0])
+  const allSameCol = cols.every((c) => c === cols[0])
+
+  if (!allSameCol && !allSameRow) return { valid: false, error: "NOT_IN_LINE" }
+
+  if (allSameRow) {
+    const minCol = Math.min(...cols)
+    const maxCol = Math.max(...cols)
+
+    for (let c = minCol; c <= maxCol; c++) {
+      const isNewTile = placements.some((p) => p.row === rows[0] && p.col === c)
+      const isOnBoard = board[rows[0]][c] !== null
+      if (!isNewTile && !isOnBoard) {
+        return { valid: false, error: "GAP_NOT_FILLED" }
+      }
+    }
+  } else {
+    const minRow = Math.min(...rows)
+    const maxRow = Math.max(...rows)
+
+    for (let r = minRow; r <= maxRow; r++) {
+      const isNewTile = placements.some((p) => p.col === cols[0] && p.row === r)
+      const isOnBoard = board[r][cols[0]] !== null
+      if (!isNewTile && !isOnBoard) {
+        return { valid: false, error: "GAP_NOT_FILLED" }
+      }
+    }
+  }
+
+  return { valid: true }
+}
+
+function isConnected(
+  placements: Placement[],
+  board: (Tile | null)[][]
+): ValidationResult {
+  const boardEmpty = board.every((row) => row.every((cell) => cell === null))
+
+  if (boardEmpty) {
+    const coversCenter = placements.some((p) => p.row === 7 && p.col === 7)
+    return coversCenter
+      ? { valid: true }
+      : { valid: false, error: "NOT_CONNECTED" }
+  }
+
+  const neighbours = [
+    [-1, 0],
+    [1, 0],
+    [0, -1],
+    [0, 1],
+  ]
+
+  const hasNeighbour = placements.some((p) =>
+    neighbours.some(([dr, dc]) => {
+      const nr = p.row + dr
+      const nc = p.col + dc
+
+      const isWithinBounds =
+        nr >= 0 && nr < board.length && nc >= 0 && nc < board[0].length
+
+      return isWithinBounds && board[nr][nc] !== null
+    })
+  )
+
+  return hasNeighbour
+    ? { valid: true }
+    : { valid: false, error: "NOT_CONNECTED" }
+}

--- a/party/lib/validation.ts
+++ b/party/lib/validation.ts
@@ -7,6 +7,10 @@ type ValidationResult =
       valid: false
       error: "NO_TILES" | "NOT_IN_LINE" | "GAP_NOT_FILLED" | "NOT_CONNECTED"
     }
+export type SubmitErrorCode = Extract<
+  ValidationResult,
+  { valid: false }
+>["error"]
 
 export function validatePlacements(
   placements: Placement[],

--- a/src/components/game/Board.tsx
+++ b/src/components/game/Board.tsx
@@ -46,6 +46,7 @@ export default function Board({ boardTiles, assignments }: BoardProps) {
                     tile={boardTiles[`${row},${col}`]!}
                     hidePoints
                     rackIndex={rackIndex}
+                    isPending={rackIndex !== undefined}
                   />
                 </div>
               )}

--- a/src/components/game/Board.tsx
+++ b/src/components/game/Board.tsx
@@ -1,19 +1,26 @@
-import {
-  BOARD_SIZE,
-  getCellType,
-  CELL_VARIANTS,
-  CELL_LABELS,
-} from "@/lib/board"
-import Cell from "@/components/game/Cell"
-import Tile from "@/components/game/Tile"
+import { BOARD_SIZE } from "@/lib/board"
 import type { TileAssignments, TileType } from "@/types/game"
+import BoardCell from "./BoardCell"
 
 interface BoardProps {
   boardTiles: Partial<Record<string, TileType>>
   assignments: TileAssignments
 }
 
+function buildAssignmentMap(assignments: TileAssignments): Map<string, number> {
+  return new Map(
+    Object.entries(assignments)
+      .filter(([, coord]) => coord != null)
+      .map(([rackIndex, coord]) => [
+        `${coord!.row},${coord!.col}`,
+        Number(rackIndex),
+      ])
+  )
+}
+
 export default function Board({ boardTiles, assignments }: BoardProps) {
+  const assignmentMap = buildAssignmentMap(assignments)
+
   return (
     <div className="@container size-[min(100cqw,100cqh)] rounded-xl bg-border p-[clamp(4px,1cqw,16px)]">
       <div
@@ -23,34 +30,14 @@ export default function Board({ boardTiles, assignments }: BoardProps) {
         {Array.from({ length: BOARD_SIZE * BOARD_SIZE }).map((_, i) => {
           const row = Math.floor(i / BOARD_SIZE)
           const col = i % BOARD_SIZE
-          const type = getCellType(row, col)
-          const rackIndexEntry = Object.entries(assignments).find(
-            ([, coord]) => coord && coord.row === row && coord.col === col
-          )
-          const rackIndex = rackIndexEntry
-            ? Number(rackIndexEntry[0])
-            : undefined
-
           return (
-            <div key={i} className="relative">
-              <Cell
-                row={row}
-                col={col}
-                variant={CELL_VARIANTS[type]}
-                label={CELL_LABELS[type]}
-                isOccupied={!!boardTiles[`${row},${col}`]}
-              />
-              {boardTiles[`${row},${col}`] && (
-                <div className="absolute inset-0 flex h-full items-center justify-center">
-                  <Tile
-                    tile={boardTiles[`${row},${col}`]!}
-                    hidePoints
-                    rackIndex={rackIndex}
-                    isPending={rackIndex !== undefined}
-                  />
-                </div>
-              )}
-            </div>
+            <BoardCell
+              key={i}
+              row={row}
+              col={col}
+              boardTile={boardTiles[`${row},${col}`]}
+              rackIndex={assignmentMap.get(`${row},${col}`)}
+            />
           )
         })}
       </div>

--- a/src/components/game/Board.tsx
+++ b/src/components/game/Board.tsx
@@ -9,7 +9,7 @@ import Tile from "@/components/game/Tile"
 import type { TileAssignments, TileType } from "@/types/room"
 
 interface BoardProps {
-  boardTiles: Partial<Record<number, TileType>>
+  boardTiles: Partial<Record<string, TileType>>
   assignments: TileAssignments
 }
 
@@ -38,11 +38,15 @@ export default function Board({ boardTiles, assignments }: BoardProps) {
                 col={col}
                 variant={CELL_VARIANTS[type]}
                 label={CELL_LABELS[type]}
-                isOccupied={!!boardTiles[i]}
+                isOccupied={!!boardTiles[`${row},${col}`]}
               />
-              {boardTiles[i] && (
+              {boardTiles[`${row},${col}`] && (
                 <div className="absolute inset-0 flex h-full items-center justify-center">
-                  <Tile tile={boardTiles[i]} hidePoints rackIndex={rackIndex} />
+                  <Tile
+                    tile={boardTiles[`${row},${col}`]!}
+                    hidePoints
+                    rackIndex={rackIndex}
+                  />
                 </div>
               )}
             </div>

--- a/src/components/game/Board.tsx
+++ b/src/components/game/Board.tsx
@@ -24,15 +24,18 @@ export default function Board({ boardTiles, assignments }: BoardProps) {
           const row = Math.floor(i / BOARD_SIZE)
           const col = i % BOARD_SIZE
           const type = getCellType(row, col)
-          const rackIndex = Number(
-            Object.entries(assignments).find(
-              ([, cellIndex]) => cellIndex === i
-            )?.[0]
+          const rackIndexEntry = Object.entries(assignments).find(
+            ([, coord]) => coord && coord.row === row && coord.col === col
           )
+          const rackIndex = rackIndexEntry
+            ? Number(rackIndexEntry[0])
+            : undefined
+
           return (
             <div key={i} className="relative">
               <Cell
-                cellIndex={i}
+                row={row}
+                col={col}
                 variant={CELL_VARIANTS[type]}
                 label={CELL_LABELS[type]}
                 isOccupied={!!boardTiles[i]}

--- a/src/components/game/Board.tsx
+++ b/src/components/game/Board.tsx
@@ -6,7 +6,7 @@ import {
 } from "@/lib/board"
 import Cell from "@/components/game/Cell"
 import Tile from "@/components/game/Tile"
-import type { TileAssignments, TileType } from "@/types/room"
+import type { TileAssignments, TileType } from "@/types/game"
 
 interface BoardProps {
   boardTiles: Partial<Record<string, TileType>>

--- a/src/components/game/BoardCell.tsx
+++ b/src/components/game/BoardCell.tsx
@@ -1,0 +1,41 @@
+import { CELL_LABELS, CELL_VARIANTS, getCellType } from "@/lib/board"
+import type { TileType } from "@/types/game"
+import Cell from "./Cell"
+import Tile from "./Tile"
+
+interface BoardCellProps {
+  row: number
+  col: number
+  boardTile?: TileType
+  rackIndex?: number
+}
+
+export default function BoardCell({
+  row,
+  col,
+  boardTile,
+  rackIndex,
+}: BoardCellProps) {
+  const type = getCellType(row, col)
+  return (
+    <div className="relative">
+      <Cell
+        row={row}
+        col={col}
+        variant={CELL_VARIANTS[type]}
+        label={CELL_LABELS[type]}
+        isOccupied={!!boardTile}
+      />
+      {boardTile && (
+        <div className="absolute inset-0 flex h-full items-center justify-center">
+          <Tile
+            tile={boardTile}
+            hidePoints
+            rackIndex={rackIndex}
+            isPending={rackIndex !== undefined}
+          />
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/game/Cell.tsx
+++ b/src/components/game/Cell.tsx
@@ -4,20 +4,22 @@ import { useDroppable } from "@dnd-kit/core"
 interface CellProps {
   variant: string
   label?: string
-  cellIndex: number
+  row: number
+  col: number
   isOccupied: boolean
 }
 
 export default function Cell({
   variant,
   label,
-  cellIndex,
+  row,
+  col,
   isOccupied,
 }: CellProps) {
   const { setNodeRef, isOver } = useDroppable({
-    id: `cell-${cellIndex}`,
+    id: `cell-${row}-${col}`,
     disabled: isOccupied,
-    data: { cellIndex },
+    data: { row, col },
   })
 
   return (

--- a/src/components/game/Tile.tsx
+++ b/src/components/game/Tile.tsx
@@ -1,5 +1,5 @@
 import { cn } from "@/lib/utils"
-import type { TileType } from "@/types/room"
+import type { TileType } from "@/types/game"
 import { useDraggable } from "@dnd-kit/core"
 import { CSS } from "@dnd-kit/utilities"
 
@@ -11,6 +11,7 @@ interface TileProps {
   rackIndex?: number
   disabled?: boolean
   hidePoints?: boolean
+  isPending?: boolean
 }
 
 export default function Tile({
@@ -18,6 +19,7 @@ export default function Tile({
   rackIndex,
   disabled,
   hidePoints,
+  isPending,
 }: TileProps) {
   const isStatic = rackIndex === undefined
 
@@ -42,13 +44,12 @@ export default function Tile({
     >
       <div
         className={cn(
-          "absolute inset-[6%] flex items-center justify-center rounded-[12%] bg-card shadow-sm ring-1 ring-border",
-          !isStatic && isDragging && "opacity-0"
+          "absolute inset-[6%] flex items-center justify-center rounded-[12%] shadow-sm ring-1 ring-border",
+          !isStatic && isDragging && "opacity-0",
+          isPending ? "bg-accent text-accent-foreground" : "bg-card"
         )}
       >
-        <span className={cn("font-bold text-foreground", LETTER_SIZE)}>
-          {tile.letter}
-        </span>
+        <span className={cn("font-bold", LETTER_SIZE)}>{tile.letter}</span>
         {!hidePoints && (
           <span
             className={cn(

--- a/src/hooks/game/useGameSession.ts
+++ b/src/hooks/game/useGameSession.ts
@@ -41,9 +41,19 @@ export function useGameSession(roomId: string) {
           case "BOARD_STATE":
             setBoardTiles(msg.board)
             break
-          case "SUBMIT_ERROR":
-            toast.error(t(`errors.submit.${msg.error}`))
+          case "SUBMIT_ERROR": {
+            const error = t(`errors.submit.${msg.error}`, {
+              returnObjects: true,
+            }) as {
+              title: string
+              description: string
+            }
+
+            toast.error(error.title, {
+              description: error.description,
+            })
             break
+          }
         }
       } catch {
         console.log("non-JSON message:", event.data)

--- a/src/hooks/game/useGameSession.ts
+++ b/src/hooks/game/useGameSession.ts
@@ -42,16 +42,16 @@ export function useGameSession(roomId: string) {
             setBoardTiles(msg.board)
             break
           case "SUBMIT_ERROR": {
-            const error = t(`errors.submit.${msg.error}`, {
-              returnObjects: true,
-            }) as {
-              title: string
-              description: string
-            }
+            const title = t(
+              `errors.submit.${msg.error}.title`,
+              "Submission Error"
+            )
+            const description = t(
+              `errors.submit.${msg.error}.description`,
+              "An error occurred while submitting."
+            )
 
-            toast.error(error.title, {
-              description: error.description,
-            })
+            toast.error(title, { description })
             break
           }
         }

--- a/src/hooks/game/useGameSession.ts
+++ b/src/hooks/game/useGameSession.ts
@@ -1,5 +1,7 @@
 import { getClientId } from "@/lib/clientId"
-import type { Player, ServerMessage, TileType } from "@/types/room"
+import type { TileType } from "@/types/game"
+import type { ServerMessage } from "@/types/messages"
+import type { Player } from "@/types/room"
 import usePartySocket from "partysocket/react"
 import { useCallback, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
@@ -14,6 +16,7 @@ export function useGameSession(roomId: string) {
   const myId = getClientId()
   const [currentTurn, setCurrentTurn] = useState<string>("")
   const [players, setPlayers] = useState<Player[]>([])
+  const [boardTiles, setBoardTiles] = useState<Record<string, TileType>>({})
 
   const socket = usePartySocket({
     host: import.meta.env.VITE_PARTYKIT_HOST ?? "localhost:1999",
@@ -34,6 +37,12 @@ export function useGameSession(roomId: string) {
             break
           case "GAME_START":
             setCurrentTurn(msg.currentTurn)
+            break
+          case "BOARD_STATE":
+            setBoardTiles(msg.board)
+            break
+          case "SUBMIT_ERROR":
+            toast.error(t(`errors.submit.${msg.error}`))
             break
         }
       } catch {
@@ -64,5 +73,5 @@ export function useGameSession(roomId: string) {
 
   const isMyTurn = currentTurn === myId
 
-  return { tiles, players, currentTurn, isMyTurn, send }
+  return { tiles, players, currentTurn, isMyTurn, boardTiles, send }
 }

--- a/src/hooks/game/useTileAssignment.ts
+++ b/src/hooks/game/useTileAssignment.ts
@@ -1,4 +1,4 @@
-import type { CellCoord, TileAssignments, TileType } from "@/types/room"
+import type { CellCoord, TileAssignments, TileType } from "@/types/game"
 import { useState } from "react"
 
 export function useTileAssignment(initialTiles: TileType[]) {

--- a/src/hooks/game/useTileAssignment.ts
+++ b/src/hooks/game/useTileAssignment.ts
@@ -22,7 +22,7 @@ export function useTileAssignment(initialTiles: TileType[]) {
     i in assignments ? null : tile
   )
 
-  const boardTiles: Partial<Record<string, TileType>> = Object.entries(
+  const pendingTiles: Partial<Record<string, TileType>> = Object.entries(
     assignments
   ).reduce(
     (acc, [rackIndex, coord]) => {
@@ -60,7 +60,7 @@ export function useTileAssignment(initialTiles: TileType[]) {
   return {
     assignments,
     rack,
-    boardTiles,
+    pendingTiles,
     assignTile,
     returnTile,
     returnAll,

--- a/src/hooks/game/useTileAssignment.ts
+++ b/src/hooks/game/useTileAssignment.ts
@@ -1,4 +1,4 @@
-import type { TileAssignments, TileType } from "@/types/room"
+import type { CellCoord, TileAssignments, TileType } from "@/types/room"
 import { useState } from "react"
 
 export function useTileAssignment(initialTiles: TileType[]) {
@@ -22,21 +22,23 @@ export function useTileAssignment(initialTiles: TileType[]) {
     i in assignments ? null : tile
   )
 
-  const boardTiles: Partial<Record<number, TileType>> = Object.entries(
+  const boardTiles: Partial<Record<string, TileType>> = Object.entries(
     assignments
   ).reduce(
-    (acc, [rackIndex, cellIndex]) => {
-      const tile = initialTiles[Number(rackIndex)]
-      if (tile) acc[Number(cellIndex)] = tile
+    (acc, [rackIndex, coord]) => {
+      if (coord) {
+        const tile = initialTiles[Number(rackIndex)]
+        if (tile) acc[`${coord.row},${coord.col}`] = tile
+      }
       return acc
     },
-    {} as Partial<Record<number, TileType>>
+    {} as Partial<Record<string, TileType>>
   )
 
-  const assignTile = (rackIndex: number, cellIndex: number) => {
+  const assignTile = (rackIndex: number, coord: CellCoord) => {
     setAssignments((prev) => ({
       ...prev,
-      [rackIndex]: cellIndex,
+      [rackIndex]: coord,
     }))
   }
 
@@ -49,8 +51,11 @@ export function useTileAssignment(initialTiles: TileType[]) {
   }
 
   const returnAll = () => setAssignments({})
-  const isOccupied = (cellIndex: number) =>
-    Object.values(assignments).includes(cellIndex)
+  const isOccupied = (row: number, col: number) => {
+    return Object.values(assignments).some(
+      (coord) => coord && coord.row === row && coord.col === col
+    )
+  }
 
   return {
     assignments,

--- a/src/lib/board.ts
+++ b/src/lib/board.ts
@@ -8,80 +8,83 @@ export type CellType =
   | "tripleWord"
   | "center"
 
-export const CELL_TYPES: Record<number, CellType> = {
-  // Triple word
-  0: "tripleWord",
-  7: "tripleWord",
-  14: "tripleWord",
-  105: "tripleWord",
-  119: "tripleWord",
-  210: "tripleWord",
-  217: "tripleWord",
-  224: "tripleWord",
+const CELL_TYPE_LIST: { row: number; col: number; type: CellType }[] = [
+  // Triple Word (8 locations)
+  { row: 0, col: 0, type: "tripleWord" },
+  { row: 0, col: 7, type: "tripleWord" },
+  { row: 0, col: 14, type: "tripleWord" },
+  { row: 7, col: 0, type: "tripleWord" },
+  { row: 7, col: 14, type: "tripleWord" },
+  { row: 14, col: 0, type: "tripleWord" },
+  { row: 14, col: 7, type: "tripleWord" },
+  { row: 14, col: 14, type: "tripleWord" },
 
-  // Double word
-  16: "doubleWord",
-  28: "doubleWord",
-  32: "doubleWord",
-  42: "doubleWord",
-  48: "doubleWord",
-  56: "doubleWord",
-  64: "doubleWord",
-  70: "doubleWord",
-  154: "doubleWord",
-  160: "doubleWord",
-  168: "doubleWord",
-  176: "doubleWord",
-  182: "doubleWord",
-  192: "doubleWord",
-  196: "doubleWord",
-  208: "doubleWord",
+  // Triple Letter (12 locations)
+  { row: 1, col: 5, type: "tripleLetter" },
+  { row: 1, col: 9, type: "tripleLetter" },
+  { row: 5, col: 1, type: "tripleLetter" },
+  { row: 5, col: 5, type: "tripleLetter" },
+  { row: 5, col: 9, type: "tripleLetter" },
+  { row: 5, col: 13, type: "tripleLetter" },
+  { row: 9, col: 1, type: "tripleLetter" },
+  { row: 9, col: 5, type: "tripleLetter" },
+  { row: 9, col: 9, type: "tripleLetter" },
+  { row: 9, col: 13, type: "tripleLetter" },
+  { row: 13, col: 5, type: "tripleLetter" },
+  { row: 13, col: 9, type: "tripleLetter" },
 
-  // Triple letter
-  20: "tripleLetter",
-  24: "tripleLetter",
-  76: "tripleLetter",
-  80: "tripleLetter",
-  84: "tripleLetter",
-  88: "tripleLetter",
-  136: "tripleLetter",
-  140: "tripleLetter",
-  144: "tripleLetter",
-  148: "tripleLetter",
-  200: "tripleLetter",
-  204: "tripleLetter",
+  // Double Word (17 locations, including center)
+  { row: 1, col: 1, type: "doubleWord" },
+  { row: 1, col: 13, type: "doubleWord" },
+  { row: 2, col: 2, type: "doubleWord" },
+  { row: 2, col: 12, type: "doubleWord" },
+  { row: 3, col: 3, type: "doubleWord" },
+  { row: 3, col: 11, type: "doubleWord" },
+  { row: 4, col: 4, type: "doubleWord" },
+  { row: 4, col: 10, type: "doubleWord" },
+  { row: 7, col: 7, type: "center" },
+  { row: 10, col: 4, type: "doubleWord" },
+  { row: 10, col: 10, type: "doubleWord" },
+  { row: 11, col: 3, type: "doubleWord" },
+  { row: 11, col: 11, type: "doubleWord" },
+  { row: 12, col: 2, type: "doubleWord" },
+  { row: 12, col: 12, type: "doubleWord" },
+  { row: 13, col: 1, type: "doubleWord" },
+  { row: 13, col: 13, type: "doubleWord" },
 
-  // Double letter
-  3: "doubleLetter",
-  11: "doubleLetter",
-  36: "doubleLetter",
-  38: "doubleLetter",
-  45: "doubleLetter",
-  52: "doubleLetter",
-  59: "doubleLetter",
-  92: "doubleLetter",
-  96: "doubleLetter",
-  98: "doubleLetter",
-  102: "doubleLetter",
-  108: "doubleLetter",
-  116: "doubleLetter",
-  126: "doubleLetter",
-  128: "doubleLetter",
-  132: "doubleLetter",
-  165: "doubleLetter",
-  172: "doubleLetter",
-  179: "doubleLetter",
-  186: "doubleLetter",
-  188: "doubleLetter",
-  213: "doubleLetter",
-  221: "doubleLetter",
+  // Double Letter (24 locations)
+  { row: 0, col: 3, type: "doubleLetter" },
+  { row: 0, col: 11, type: "doubleLetter" },
+  { row: 2, col: 6, type: "doubleLetter" },
+  { row: 2, col: 8, type: "doubleLetter" },
+  { row: 3, col: 0, type: "doubleLetter" },
+  { row: 3, col: 7, type: "doubleLetter" },
+  { row: 3, col: 14, type: "doubleLetter" },
+  { row: 6, col: 2, type: "doubleLetter" },
+  { row: 6, col: 6, type: "doubleLetter" },
+  { row: 6, col: 8, type: "doubleLetter" },
+  { row: 6, col: 12, type: "doubleLetter" },
+  { row: 7, col: 3, type: "doubleLetter" },
+  { row: 7, col: 11, type: "doubleLetter" },
+  { row: 8, col: 2, type: "doubleLetter" },
+  { row: 8, col: 6, type: "doubleLetter" },
+  { row: 8, col: 8, type: "doubleLetter" },
+  { row: 8, col: 12, type: "doubleLetter" },
+  { row: 11, col: 0, type: "doubleLetter" },
+  { row: 11, col: 7, type: "doubleLetter" },
+  { row: 11, col: 14, type: "doubleLetter" },
+  { row: 12, col: 6, type: "doubleLetter" },
+  { row: 12, col: 8, type: "doubleLetter" },
+  { row: 14, col: 3, type: "doubleLetter" },
+  { row: 14, col: 11, type: "doubleLetter" },
+]
 
-  // Center
-  112: "center",
-}
+const CELL_TYPE_MAP = new Map<string, CellType>(
+  CELL_TYPE_LIST.map(({ row, col, type }) => [`${row},${col}`, type])
+)
 
 export function getCellType(row: number, col: number): CellType {
-  return CELL_TYPES[row * BOARD_SIZE + col] ?? "normal"
+  return CELL_TYPE_MAP.get(`${row},${col}`) ?? "normal"
 }
 
 export const CELL_VARIANTS = {

--- a/src/lib/board.ts
+++ b/src/lib/board.ts
@@ -33,7 +33,7 @@ const CELL_TYPE_LIST: { row: number; col: number; type: CellType }[] = [
   { row: 13, col: 5, type: "tripleLetter" },
   { row: 13, col: 9, type: "tripleLetter" },
 
-  // Double Word (17 locations, including center)
+  // Double Word (16 locations; center is separate)
   { row: 1, col: 1, type: "doubleWord" },
   { row: 1, col: 13, type: "doubleWord" },
   { row: 2, col: 2, type: "doubleWord" },

--- a/src/locales/en/game.json
+++ b/src/locales/en/game.json
@@ -11,7 +11,7 @@
       },
       "GAP_NOT_FILLED": {
         "title": "Invalid gap",
-        "description": "Your tiles must connect to existing tiles or be placed contiguously without gaps."
+        "description": "Tiles must connect to existing tiles and be placed contiguously (no gaps)."
       },
       "NOT_CONNECTED": {
         "title": "Not connected",

--- a/src/locales/en/game.json
+++ b/src/locales/en/game.json
@@ -1,5 +1,23 @@
 {
   "errors": {
+    "submit": {
+      "NO_TILES": {
+        "title": "No tiles placed",
+        "description": "Please place at least one tile on the board."
+      },
+      "NOT_IN_LINE": {
+        "title": "Invalid placement",
+        "description": "Tiles must be placed in a straight horizontal or vertical line."
+      },
+      "GAP_NOT_FILLED": {
+        "title": "Invalid gap",
+        "description": "Your tiles must connect to existing tiles or be placed contiguously without gaps."
+      },
+      "NOT_CONNECTED": {
+        "title": "Not connected",
+        "description": "Your word must connect to the existing board."
+      }
+    },
     "connection": {
       "failed": {
         "title": "Connection failed",

--- a/src/locales/en/game.json
+++ b/src/locales/en/game.json
@@ -16,6 +16,18 @@
       "NOT_CONNECTED": {
         "title": "Not connected",
         "description": "Your word must connect to the existing board."
+      },
+      "OUT_OF_BOUNDS": {
+        "title": "Invalid placement",
+        "description": "One or more tiles were placed outside the board boundaries."
+      },
+      "CELL_OCCUPIED": {
+        "title": "Cell occupied",
+        "description": "One or more tiles overlap with tiles already on the board."
+      },
+      "DUPLICATE_COORDINATE": {
+        "title": "Duplicate placement",
+        "description": "You placed more than one tile in the same cell."
       }
     },
     "connection": {

--- a/src/pages/Game.tsx
+++ b/src/pages/Game.tsx
@@ -92,12 +92,13 @@ function GameSessionView({ roomId }: { roomId: string }) {
   const handleSubmitTurn = () => {
     isSubmittingRef.current = true
 
-    const placements = Object.entries(assignments).map(
-      ([rackIndex, coord]) => ({
+    const placements = Object.entries(assignments)
+      .filter(([, coord]) => coord != null)
+      .map(([rackIndex, coord]) => ({
         rackIndex: Number(rackIndex),
-        ...coord,
-      })
-    )
+        row: coord!.row,
+        col: coord!.col,
+      }))
 
     send({ type: "SUBMIT_TURN", placements })
   }

--- a/src/pages/Game.tsx
+++ b/src/pages/Game.tsx
@@ -79,7 +79,8 @@ function GameSessionView({ roomId }: { roomId: string }) {
         typeof overData?.col !== "number"
       )
         return
-      if (isOccupied(overData.row, overData.col)) return
+      const coordKey = `${overData.row},${overData.col}`
+      if (isOccupied(overData.row, overData.col) || boardTiles[coordKey]) return
       assignTile(activeData.rackIndex, { row: overData.row, col: overData.col })
     }
   }

--- a/src/pages/Game.tsx
+++ b/src/pages/Game.tsx
@@ -6,7 +6,7 @@ import RoomLayout from "@/components/room/RoomLayout"
 import { Button } from "@/components/ui/button"
 import { useGameSession } from "@/hooks/game/useGameSession"
 import { useTileAssignment } from "@/hooks/game/useTileAssignment"
-import type { TileType } from "@/types/room"
+import type { TileType } from "@/types/game"
 import {
   DndContext,
   DragOverlay,
@@ -21,16 +21,18 @@ import { useEffect, useRef, useState } from "react"
 import { useParams } from "react-router"
 
 function GameSessionView({ roomId }: { roomId: string }) {
-  const { tiles, players, currentTurn, isMyTurn, send } = useGameSession(roomId)
+  const { tiles, players, currentTurn, isMyTurn, boardTiles, send } =
+    useGameSession(roomId)
   const {
     rack,
     assignTile,
-    boardTiles,
+    pendingTiles,
     returnTile,
     isOccupied,
     returnAll,
     assignments,
   } = useTileAssignment(tiles)
+  const mergedBoardTiles = { ...boardTiles, ...pendingTiles }
   const [activeTile, setActiveTile] = useState<TileType | null>(null)
 
   const isSubmittingRef = useRef(false)
@@ -109,7 +111,7 @@ function GameSessionView({ roomId }: { roomId: string }) {
       <RoomLayout roomId={roomId}>
         <ScoreBoardList players={players} currentTurn={currentTurn} />
         <div className="@container-[size] flex min-h-0 w-full flex-1 items-center justify-center">
-          <Board boardTiles={boardTiles} assignments={assignments} />
+          <Board boardTiles={mergedBoardTiles} assignments={assignments} />
         </div>
         <div className="flex w-full items-center gap-2">
           <Button

--- a/src/pages/Game.tsx
+++ b/src/pages/Game.tsx
@@ -63,7 +63,9 @@ function GameSessionView({ roomId }: { roomId: string }) {
     if (!over || !active) return
 
     const activeData = active.data.current as { rackIndex?: number } | undefined
-    const overData = over.data.current as { cellIndex?: number } | undefined
+    const overData = over.data.current as
+      | { row?: number; col?: number }
+      | undefined
 
     if (over.id === "rack") {
       if (typeof activeData?.rackIndex != "number") return
@@ -71,11 +73,12 @@ function GameSessionView({ roomId }: { roomId: string }) {
     } else {
       if (
         typeof activeData?.rackIndex !== "number" ||
-        typeof overData?.cellIndex !== "number"
+        typeof overData?.row !== "number" ||
+        typeof overData?.col !== "number"
       )
         return
-      if (isOccupied(overData.cellIndex)) return
-      assignTile(activeData.rackIndex, overData.cellIndex)
+      if (isOccupied(overData.row, overData.col)) return
+      assignTile(activeData.rackIndex, { row: overData.row, col: overData.col })
     }
   }
 
@@ -85,7 +88,15 @@ function GameSessionView({ roomId }: { roomId: string }) {
 
   const handleSubmitTurn = () => {
     isSubmittingRef.current = true
-    send({ type: "SUBMIT_TURN" })
+
+    const placements = Object.entries(assignments).map(
+      ([rackIndex, coord]) => ({
+        rackIndex: Number(rackIndex),
+        ...coord,
+      })
+    )
+
+    send({ type: "SUBMIT_TURN", placements })
   }
 
   return (

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -1,0 +1,11 @@
+export interface TileType {
+  letter: string
+  points: number
+}
+
+export interface CellCoord {
+  row: number
+  col: number
+}
+
+export type TileAssignments = Partial<Record<number, CellCoord>>

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -7,6 +7,11 @@ export type ServerMessage =
   | { type: "GAME_START"; roomId: string; currentTurn: string }
   | { type: "TURN_CHANGE"; currentTurn: string }
   | { type: "RACK_STATE"; tiles: TileType[] }
+  | { type: "BOARD_STATE"; board: Record<string, TileType> }
+  | {
+      type: "SUBMIT_ERROR"
+      error: "NO_TILES" | "NOT_IN_LINE" | "GAP_NOT_FILLED" | "NOT_CONNECTED"
+    }
 
 export type ClientMessage =
   | { type: "READY" }

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -4,7 +4,7 @@ import type { Player } from "./room"
 export type ServerMessage =
   | { type: "ROOM_STATE"; players: Player[] }
   | { type: "ROOM_FULL" }
-  | { type: "GAME_START"; roomId: string; currentTurn: string }
+  | { type: "GAME_START"; currentTurn: string; roomId?: string }
   | { type: "TURN_CHANGE"; currentTurn: string }
   | { type: "RACK_STATE"; tiles: TileType[] }
   | { type: "BOARD_STATE"; board: Record<string, TileType> }

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -1,0 +1,17 @@
+import type { TileType } from "./game"
+import type { Player } from "./room"
+
+export type ServerMessage =
+  | { type: "ROOM_STATE"; players: Player[] }
+  | { type: "ROOM_FULL" }
+  | { type: "GAME_START"; roomId: string; currentTurn: string }
+  | { type: "TURN_CHANGE"; currentTurn: string }
+  | { type: "RACK_STATE"; tiles: TileType[] }
+
+export type ClientMessage =
+  | { type: "READY" }
+  | { type: "UNREADY" }
+  | {
+      type: "SUBMIT_TURN"
+      placements: { rackIndex: number; row: number; col: number }[]
+    }

--- a/src/types/room.ts
+++ b/src/types/room.ts
@@ -1,33 +1,6 @@
-export type ServerMessage =
-  | { type: "ROOM_STATE"; players: Player[] }
-  | { type: "ROOM_FULL" }
-  | { type: "GAME_START"; roomId: string; currentTurn: string }
-  | { type: "TURN_CHANGE"; currentTurn: string }
-  | { type: "RACK_STATE"; tiles: TileType[] }
-
-export type ClientMessage =
-  | { type: "READY" }
-  | { type: "UNREADY" }
-  | {
-      type: "SUBMIT_TURN"
-      placements: { rackIndex: number; row: number; col: number }[]
-    }
-
 export interface Player {
   id: string
   ready: boolean
 }
 
-export interface TileType {
-  letter: string
-  points: number
-}
-
-export type TileAssignments = Partial<Record<number, CellCoord>>
-
 export type PlayerStatus = "ready" | "not-ready" | "your-turn" | "their-turn"
-
-export interface CellCoord {
-  row: number
-  col: number
-}

--- a/src/types/room.ts
+++ b/src/types/room.ts
@@ -10,7 +10,7 @@ export type ClientMessage =
   | { type: "UNREADY" }
   | {
       type: "SUBMIT_TURN"
-      placements: { rackIndex: number; cellIndex: number }[]
+      placements: { rackIndex: number; row: number; col: number }[]
     }
 
 export interface Player {
@@ -23,6 +23,11 @@ export interface TileType {
   points: number
 }
 
-export type TileAssignments = Partial<Record<number, number>>
+export type TileAssignments = Partial<Record<number, CellCoord>>
 
 export type PlayerStatus = "ready" | "not-ready" | "your-turn" | "their-turn"
+
+export interface CellCoord {
+  row: number
+  col: number
+}


### PR DESCRIPTION
Adds server-side board state management and tile placement validation, wiring up the full submit-turn flow. The board is now tracked as a 2D array on the server, broadcast to all clients on change, and validated before any tiles are committed. On the frontend, cell coordinates shift from flat indices to `{row, col}` pairs throughout, types are reorganised into dedicated `game.ts` and `messages.ts` files, and pending tiles render with a distinct accent style so players can distinguish placed-but-not-submitted tiles from committed ones.

## Changes

- Added `board` state to `Server` as a 2D `(Tile | null)[][]` array, initialised on construction and updated on each valid submission
- Created `party/lib/validation.ts` with `validatePlacements` — enforces no-tiles, inline, gap-free, and connectivity (including first-move center) rules
- Added `broadcastBoardState` to `party/lib/messages.ts` to serialise the board as a flat `Record<string, Tile>` and broadcast `BOARD_STATE` to all clients; fixed a bug where the broadcast was incorrectly inside the inner loop
- Added `sendSubmitError` to `party/lib/messages.ts` to send typed `SUBMIT_ERROR` messages back to the submitting player
- Updated `onMessage` in `Server` to validate placements, write tiles to `this.board`, and broadcast board state before advancing the turn
- Fixed `SUBMIT_TURN` response message type from `"RACK"` to `"RACK_STATE"` in `party/index.ts`
- Updated `isPlacement` type guard in `party/lib/types.ts` to require and validate `row` and `col` fields; renamed `rack: _` to `rack: _rack` to satisfy the no-unused-vars rule
- Added `BOARD_SIZE` constant to `party/constants.ts`
- Extracted `TileType`, `CellCoord`, and `TileAssignments` into `src/types/game.ts`; moved all `ServerMessage`/`ClientMessage` types into `src/types/messages.ts`; trimmed `src/types/room.ts` to `Player` and `PlayerStatus` only
- Refactored `Cell` to accept `row`/`col` props instead of a flat `cellIndex`, updating the droppable `id` and `data` accordingly
- Updated `useTileAssignment` to store `CellCoord` values in `assignments`, derive `pendingTiles` as `Record<string, TileType>`, and accept `{row, col}` in `assignTile` and `isOccupied`
- Updated `useGameSession` to track `boardTiles` from `BOARD_STATE` messages and handle `SUBMIT_ERROR` by looking up localised error strings and showing a toast
- Merged `boardTiles` (server-committed) and `pendingTiles` (local, unsubmitted) in `Game.tsx` before passing to `Board`
- Updated `handleSubmitTurn` in `Game.tsx` to map `assignments` to `{rackIndex, row, col}` placements and include them in the `SUBMIT_TURN` message
- Added `isPending` prop to `Tile` to render unsubmitted tiles with `bg-accent` instead of `bg-card`
- Refactored `src/lib/board.ts` cell type lookup from a flat integer-keyed record to a `Map<string, CellType>` keyed by `"row,col"`, with corrected Scrabble-standard coordinates
- Added submit error i18n keys (`NO_TILES`, `NOT_IN_LINE`, `GAP_NOT_FILLED`, `NOT_CONNECTED`) to `src/locales/en/game.json`
- Added ESLint `@typescript-eslint/no-unused-vars` rule with underscore-prefix ignore patterns

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- **eslint.config.js** - Configure TypeScript ESLint rule for unused variables, allowing underscore-prefixed identifiers to be ignored

- **party/constants.ts** - Add `BOARD_SIZE` constant (15) for board dimensions

- **party/index.ts** - Initialize server-side 2D `board: (Tile | null)[][]`; validate placements before applying; apply validated placements to the server board, broadcast board state after a successful turn, advance turns; send typed `SUBMIT_ERROR` on invalid submissions; restore board state to reconnecting clients; fix broadcast placement bug

- **party/lib/messages.ts** - Add `broadcastBoardState(room, board)` to send flattened board state as a `"row,col"` → Tile mapping; add `sendSubmitError(conn, error)` for typed submit-error messaging

- **party/lib/types.ts** - Add `CellCoord { row, col }`; expand `isPlacement()` type guard to include `row`/`col`; update `toPublicPlayer()` to exclude `rack` field in public view

- **party/lib/validation.ts** - Add `validatePlacements(placements, board)` and `SubmitErrorCode` type; enforce: non-empty (`NO_TILES`), in-line single row/column (`NOT_IN_LINE`), no gaps between min/max extent (`GAP_NOT_FILLED`), bounds (`OUT_OF_BOUNDS`), no collisions (`CELL_OCCUPIED`), no duplicate coords (`DUPLICATE_COORDINATE`), and connectivity (first-move center `(7,7)` or adjacency to existing tiles → `NOT_CONNECTED`)

- **src/components/game/Board.tsx** - Switch board tile lookup to `Partial<Record<string, TileType>>` keyed by `"row,col"`; build `assignmentMap` from `TileAssignments` to map `"row,col"` → `rackIndex`; render `BoardCell` per `row,col`

- **src/components/game/BoardCell.tsx** - New component: compute cell type via `getCellType(row, col)`, render `Cell`, overlay `Tile` when present, pass `hidePoints`, `rackIndex`, and `isPending` (when assignment exists)

- **src/components/game/Cell.tsx** - Replace `cellIndex` prop with `row`/`col`; droppable id/data use `cell-${row}-${col}` and `{ row, col }`; `disabled` still driven by `isOccupied`

- **src/components/game/Tile.tsx** - Add optional `isPending?: boolean`; render pending tiles with accent styling (`bg-accent text-accent-foreground`) when `isPending`

- **src/hooks/game/useGameSession.ts** - Add `boardTiles: Record<string, TileType>` state populated from `BOARD_STATE` messages; include `boardTiles` in returned hook API

- **src/hooks/game/useTileAssignment.ts** - Migrate to row/col coordinate system and `CellCoord`; assignments now map numeric rack indices → `CellCoord`; expose `pendingTiles` keyed by `"row,col"`; `assignTile(rackIndex, coord)` and `isOccupied(row, col)` updated; remove prior numeric `boardTiles` from the hook

- **src/lib/board.ts** - Replace flat numeric `CELL_TYPES` with `CELL_TYPE_LIST` of `{row, col, type}` and an internal `Map` keyed by `"row,col"`; update `getCellType(row, col)` to query the map and default to `"normal"`

- **src/locales/en/game.json** - Add i18n `errors.submit` keys for submit/placement validation: `NO_TILES`, `NOT_IN_LINE`, `GAP_NOT_FILLED`, `NOT_CONNECTED`, `OUT_OF_BOUNDS`, `CELL_OCCUPIED`, `DUPLICATE_COORDINATE` (with shortened text for gap message)

- **src/pages/Game.tsx** - Merge server `boardTiles` with local `pendingTiles` for Board render so in-flight placements display; update drop handler to use `{ row, col }` and occupancy checks; build `placements` array from assignments as `{ rackIndex, row, col }` for `SUBMIT_TURN`

- **src/types/game.ts** - New module: export `TileType { letter, points }`, `CellCoord { row, col }`, and `TileAssignments = Partial<Record<number, CellCoord>>`

- **src/types/messages.ts** - New module: export discriminated union `ServerMessage` and `ClientMessage` types modeling wire protocol, including `BOARD_STATE`, `SUBMIT_ERROR` with constrained `SubmitErrorCode` strings, and `SUBMIT_TURN` payload with `{ rackIndex, row, col }`

- **src/types/room.ts** - Remove moved message/tile types; keep `Player` interface and add `PlayerStatus = "ready" | "not-ready" | "your-turn" | "their-turn"`

- **Other** - Adjust ESLint unused-var rule to ignore underscore-prefixed identifiers; add `BOARD_SIZE` constant usage and i18n keys; minor commit-series fixes for placement bounds, collision checks, filtering null coords, and allowing `GAME_START` messages to omit `roomId`

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ImDarkly/mova/pull/52?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->