### PR TITLE
Adjust PartyKit host binding and refine type definitions

### DIFF
--- a/src/hooks/game/useGameSession.ts
+++ b/src/hooks/game/useGameSession.ts
@@ -19,7 +19,7 @@ export function useGameSession(roomId: string) {
   const [boardTiles, setBoardTiles] = useState<Record<string, TileType>>({})
 
   const socket = usePartySocket({
-    host: import.meta.env.VITE_PARTYKIT_HOST ?? "localhost:1999",
+    host: `${window.location.hostname}:1999`,
     room: roomId,
     id: myId,
     onMessage(event) {

--- a/src/hooks/room/useRoomSession.ts
+++ b/src/hooks/room/useRoomSession.ts
@@ -2,9 +2,10 @@ import { toast } from "sonner"
 import { useTranslation } from "react-i18next"
 import { useNavigate } from "react-router"
 import { useRef, useState } from "react"
-import type { Player, ServerMessage } from "@/types/room"
+import type { Player } from "@/types/room"
 import usePartySocket from "partysocket/react"
 import { getClientId } from "@/lib/clientId"
+import type { ServerMessage } from "@/types/messages"
 
 export function useRoomSession(roomId: string) {
   const { t } = useTranslation("room")
@@ -13,7 +14,7 @@ export function useRoomSession(roomId: string) {
   const intentionalClose = useRef(false)
 
   const socket = usePartySocket({
-    host: import.meta.env.VITE_PARTYKIT_HOST ?? "localhost:1999",
+    host: `${window.location.hostname}:1999`,
     room: roomId,
     id: getClientId(),
     onMessage(event) {
@@ -39,7 +40,9 @@ export function useRoomSession(roomId: string) {
         console.log("non-JSON message:", event.data)
       }
     },
+
     onError() {
+      intentionalClose.current = true
       toast.error(t("errors.connection.failed.title"), {
         description: t("errors.connection.failed.description"),
       })

--- a/src/types/room.ts
+++ b/src/types/room.ts
@@ -1,6 +1,7 @@
 export interface Player {
   id: string
   ready: boolean
+  connected: boolean
 }
 
 export type PlayerStatus = "ready" | "not-ready" | "your-turn" | "their-turn"


### PR DESCRIPTION
## What
Updated PartyKit socket host resolution to use the current browser hostname, added player connection state tracking, and fixed room session error handling behavior.

## Why
To make multiplayer connections work across environments without relying on `VITE_PARTYKIT_HOST`, support disconnected player state in the room model, and prevent duplicate disconnect handling after socket errors.

## How
- Replaced `import.meta.env.VITE_PARTYKIT_HOST ?? "localhost:1999"` with ``${window.location.hostname}:1999`` in `useGameSession.ts` and `useRoomSession.ts` so PartySocket resolves against the active host automatically.
- Moved `ServerMessage` import in `useRoomSession.ts` from `@/types/room` to `@/types/messages` to match the actual message type location.
- Added `connected: boolean` to the `Player` interface in `src/types/room.ts` for connection-aware room state.
- Updated `useRoomSession.ts` `onError` handler to set `intentionalClose.current = true` before showing the connection failure toast, preventing unintended reconnect/disconnect side effects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **src/hooks/game/useGameSession.ts**: PartySocket host resolution changed from environment variable fallback to `window.location.hostname:1999` for automatic cross-environment connectivity
- **src/hooks/room/useRoomSession.ts**: 
  - PartySocket host resolution changed from environment variable to `window.location.hostname:1999`
  - Error handler updated to set `intentionalClose.current = true` before toast display to prevent duplicate disconnect handling
  - `ServerMessage` import moved from `@/types/room` to `@/types/messages` for correct type location
- **src/types/room.ts**: `Player` interface augmented with `connected: boolean` field to track player connection state

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ImDarkly/mova/pull/54?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->