### PR TITLE
Use i18n labels for board cell types

### DIFF
--- a/src/components/game/BoardCell.tsx
+++ b/src/components/game/BoardCell.tsx
@@ -1,7 +1,8 @@
-import { CELL_LABELS, CELL_VARIANTS, getCellType } from "@/lib/board"
+import { CELL_VARIANTS, getCellType } from "@/lib/board"
 import type { TileType } from "@/types/game"
 import Cell from "./Cell"
 import Tile from "./Tile"
+import { useTranslation } from "react-i18next"
 
 interface BoardCellProps {
   row: number
@@ -17,13 +18,16 @@ export default function BoardCell({
   rackIndex,
 }: BoardCellProps) {
   const type = getCellType(row, col)
+  const { t } = useTranslation("board")
+  const label = type === "normal" ? "" : t(`cellLabels.${type}`)
+
   return (
     <div className="relative">
       <Cell
         row={row}
         col={col}
         variant={CELL_VARIANTS[type]}
-        label={CELL_LABELS[type]}
+        label={label}
         isOccupied={!!boardTile}
       />
       {boardTile && (

--- a/src/lib/board.ts
+++ b/src/lib/board.ts
@@ -96,13 +96,4 @@ export const CELL_VARIANTS = {
   center: "bg-primary/10 text-primary/70",
 } as const satisfies Record<CellType, string>
 
-export const CELL_LABELS: Record<CellType, string> = {
-  normal: "",
-  doubleLetter: "DL",
-  tripleLetter: "TL",
-  doubleWord: "DW",
-  tripleWord: "TW",
-  center: "★",
-}
-
 export type CellVariant = (typeof CELL_VARIANTS)[CellType]


### PR DESCRIPTION
## What
Replace hardcoded `CELL_LABELS` in `src/lib/board.ts` with locale-backed labels resolved via `useTranslation` in `BoardCell.tsx`.

## Why
`CELL_LABELS` duplicated strings already defined in `src/locales/en/board.json`, making the locale file silently inert.

## How
- Deleted `CELL_LABELS` export from `board.ts`; `board.json` `cellLabels` is now the single source of truth
- `BoardCell` calls `useTranslation("board")` and resolves `t("cellLabels.${type}")`, short-circuiting to `""` for `"normal"` cells to avoid a needless lookup
- No changes to `board.json` — its keys already match the `CellType` union exactly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **src/components/game/BoardCell.tsx** — Use `react-i18next` to resolve cell labels from the `board` namespace instead of static mapping; returns empty string for "normal" type, otherwise translates via `t("cellLabels.${type}")`

- **src/lib/board.ts** — Remove exported `CELL_LABELS` constant to eliminate duplication and centralize board cell labels in i18n locale file

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ImDarkly/mova/pull/55?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->