### PR TITLE
Add score support to scoreboard and messages

### DIFF
--- a/src/components/game/ScoreBoardItem.tsx
+++ b/src/components/game/ScoreBoardItem.tsx
@@ -8,12 +8,14 @@ interface ScoreBoardItemProps {
   player: Player
   isMe: boolean
   currentTurn?: string
+  score: number
 }
 
 export default function ScoreBoardItem({
   player,
   isMe,
   currentTurn,
+  score,
 }: ScoreBoardItemProps) {
   const { t } = useTranslation("game")
   const isTurnHolder = player.id === currentTurn
@@ -28,6 +30,9 @@ export default function ScoreBoardItem({
           {player.id}
           {isMe && <Badge variant="outline">{t("labels.you")}</Badge>}
         </ItemTitle>
+      </ItemContent>
+      <ItemContent>
+        <span>{score}</span>
       </ItemContent>
     </Item>
   )

--- a/src/components/game/ScoreBoardList.tsx
+++ b/src/components/game/ScoreBoardList.tsx
@@ -2,15 +2,17 @@ import type { Player } from "@/types/room"
 import ScoreBoardItem from "./ScoreBoardItem"
 import { getClientId } from "@/lib/clientId"
 
-interface ScoreBoardItemProps {
+interface ScoreBoardListProps {
   players: Player[]
   currentTurn?: string
+  scores: Record<string, number>
 }
 
 export default function ScoreBoardList({
   players,
   currentTurn,
-}: ScoreBoardItemProps) {
+  scores,
+}: ScoreBoardListProps) {
   const myId = getClientId()
 
   return (
@@ -22,6 +24,7 @@ export default function ScoreBoardList({
             player={player}
             isMe={myId === player.id}
             currentTurn={currentTurn}
+            score={scores[player.id] ?? 0}
           />
         )
       })}

--- a/src/hooks/game/useGameSession.ts
+++ b/src/hooks/game/useGameSession.ts
@@ -17,6 +17,7 @@ export function useGameSession(roomId: string) {
   const [currentTurn, setCurrentTurn] = useState<string>("")
   const [players, setPlayers] = useState<Player[]>([])
   const [boardTiles, setBoardTiles] = useState<Record<string, TileType>>({})
+  const [scores, setScores] = useState<Record<string, number>>({})
 
   const socket = usePartySocket({
     host: `${window.location.hostname}:1999`,
@@ -31,12 +32,14 @@ export function useGameSession(roomId: string) {
             break
           case "TURN_CHANGE":
             setCurrentTurn(msg.currentTurn)
+            setScores(msg.scores)
             break
           case "ROOM_STATE":
             setPlayers(msg.players)
             break
           case "GAME_START":
             setCurrentTurn(msg.currentTurn)
+            setScores(msg.scores)
             break
           case "BOARD_STATE":
             setBoardTiles(msg.board)
@@ -83,5 +86,5 @@ export function useGameSession(roomId: string) {
 
   const isMyTurn = currentTurn === myId
 
-  return { tiles, players, currentTurn, isMyTurn, boardTiles, send }
+  return { tiles, players, currentTurn, isMyTurn, boardTiles, send, scores }
 }

--- a/src/pages/Game.tsx
+++ b/src/pages/Game.tsx
@@ -21,7 +21,7 @@ import { useEffect, useRef, useState } from "react"
 import { useParams } from "react-router"
 
 function GameSessionView({ roomId }: { roomId: string }) {
-  const { tiles, players, currentTurn, isMyTurn, boardTiles, send } =
+  const { tiles, players, currentTurn, isMyTurn, boardTiles, send, scores } =
     useGameSession(roomId)
   const {
     rack,
@@ -111,7 +111,11 @@ function GameSessionView({ roomId }: { roomId: string }) {
       onDragCancel={handleDragCancel}
     >
       <RoomLayout roomId={roomId}>
-        <ScoreBoardList players={players} currentTurn={currentTurn} />
+        <ScoreBoardList
+          players={players}
+          currentTurn={currentTurn}
+          scores={scores}
+        />
         <div className="@container-[size] flex min-h-0 w-full flex-1 items-center justify-center">
           <Board boardTiles={mergedBoardTiles} assignments={assignments} />
         </div>

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -4,8 +4,13 @@ import type { Player } from "./room"
 export type ServerMessage =
   | { type: "ROOM_STATE"; players: Player[] }
   | { type: "ROOM_FULL" }
-  | { type: "GAME_START"; currentTurn: string; roomId?: string }
-  | { type: "TURN_CHANGE"; currentTurn: string }
+  | {
+      type: "GAME_START"
+      currentTurn: string
+      roomId?: string
+      scores: Record<string, number>
+    }
+  | { type: "TURN_CHANGE"; currentTurn: string; scores: Record<string, number> }
   | { type: "RACK_STATE"; tiles: TileType[] }
   | { type: "BOARD_STATE"; board: Record<string, TileType> }
   | {


### PR DESCRIPTION
## What
Wire live scores from server into the scoreboard UI.

## Why
Scores were tracked server-side but never sent to or displayed in the client.

## How
- Added `scores: Record<string, number>` to `GAME_START` and `TURN_CHANGE` message types in `messages.ts`
- `useGameSession` initialises `scores` state and updates it on both message types, exposes via return value
- `ScoreBoardList` accepts `scores` prop and passes `scores[player.id] ?? 0` per player into `ScoreBoardItem`
- `ScoreBoardItem` renders score in a second `<ItemContent>` block

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changed Components

- **`src/types/messages.ts`** — Added `scores: Record<string, number>` payload to `GAME_START` and `TURN_CHANGE` message types

- **`src/hooks/game/useGameSession.ts`** — Initialize and track `scores` state; update from incoming `GAME_START` and `TURN_CHANGE` messages; expose `scores` in hook return value

- **`src/components/game/ScoreBoardList.tsx`** — Accept `scores` prop; pass computed `scores[player.id] ?? 0` to each `ScoreBoardItem`

- **`src/components/game/ScoreBoardItem.tsx`** — Accept and render `score` prop in scoreboard display

- **`src/pages/Game.tsx`** — Destructure `scores` from `useGameSession` hook; pass to `ScoreBoardList` component

<!-- end of auto-generated comment: release notes by coderabbit.ai -->