### PR TITLE
Implement player name handling and display in game features

### DIFF
--- a/party/index.ts
+++ b/party/index.ts
@@ -48,8 +48,12 @@ export default class Server implements Party.Server {
         return
       }
       this.playerOrder.push(conn.id)
+      const url = new URL(conn.uri)
+      const name = url.searchParams.get("name")?.trim() || conn.id
+
       this.players[conn.id] = {
         id: conn.id,
+        name,
         ready: false,
         rack: [],
         connected: true,

--- a/party/lib/types.ts
+++ b/party/lib/types.ts
@@ -5,6 +5,7 @@ export interface Tile {
 
 export interface Player {
   id: string
+  name: string
   ready: boolean
   rack: Tile[]
   connected: boolean

--- a/src/components/game/ScoreBoardItem.tsx
+++ b/src/components/game/ScoreBoardItem.tsx
@@ -27,7 +27,7 @@ export default function ScoreBoardItem({
     >
       <ItemContent>
         <ItemTitle>
-          {player.id}
+          {player.name}
           {isMe && <Badge variant="outline">{t("labels.you")}</Badge>}
         </ItemTitle>
       </ItemContent>

--- a/src/components/room/CreateRoomButton.tsx
+++ b/src/components/room/CreateRoomButton.tsx
@@ -2,9 +2,13 @@ import { useCreateRoom } from "@/hooks/room/useCreateRoom"
 import { Button } from "@/components/ui/button"
 import { useTranslation } from "react-i18next"
 
-export default function CreateRoomButton() {
+export default function CreateRoomButton({ disabled }: { disabled?: boolean }) {
   const { t } = useTranslation("room")
   const createRoom = useCreateRoom()
 
-  return <Button onClick={createRoom}>{t("actions.createRoom")}</Button>
+  return (
+    <Button disabled={disabled} onClick={createRoom}>
+      {t("actions.createRoom")}
+    </Button>
+  )
 }

--- a/src/components/room/JoinRoomInput.tsx
+++ b/src/components/room/JoinRoomInput.tsx
@@ -11,7 +11,7 @@ import { REGEXP_ONLY_DIGITS_AND_CHARS } from "input-otp"
 import { Hash } from "lucide-react"
 import { ROOM_CODE_LENGTH } from "@/lib/roomId"
 
-export default function JoinRoomInput() {
+export default function JoinRoomInput({ disabled }: { disabled?: boolean }) {
   const { t } = useTranslation("room")
   const [code, setCode] = useState("")
   const joinRoom = useJoinRoom()
@@ -40,7 +40,7 @@ export default function JoinRoomInput() {
         </InputOTPGroup>
       </InputOTP>
       <Button
-        disabled={code.length !== ROOM_CODE_LENGTH}
+        disabled={code.length !== ROOM_CODE_LENGTH || disabled}
         variant="secondary"
         onClick={handleJoin}
       >

--- a/src/components/room/PlayerItem.tsx
+++ b/src/components/room/PlayerItem.tsx
@@ -19,7 +19,7 @@ export default function PlayerItem({ player, isMe }: PlayerItemProps) {
     >
       <ItemContent>
         <ItemTitle>
-          {player.id}
+          {player.name}
           {isMe && <Badge variant="outline">{t("labels.you")}</Badge>}
         </ItemTitle>
       </ItemContent>

--- a/src/hooks/game/useGameSession.ts
+++ b/src/hooks/game/useGameSession.ts
@@ -7,6 +7,7 @@ import { useCallback, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { useNavigate } from "react-router"
 import { toast } from "sonner"
+import { getPlayerName } from "@/lib/playerName"
 
 export function useGameSession(roomId: string) {
   const { t } = useTranslation("game")
@@ -27,6 +28,9 @@ export function useGameSession(roomId: string) {
     host: `${window.location.hostname}:1999`,
     room: roomId,
     id: myId,
+    query: {
+      name: getPlayerName() ?? "",
+    },
     onMessage(event) {
       try {
         const msg = JSON.parse(event.data) as ServerMessage

--- a/src/hooks/room/useRoomSession.ts
+++ b/src/hooks/room/useRoomSession.ts
@@ -7,6 +7,7 @@ import usePartySocket from "partysocket/react"
 import { getClientId } from "@/lib/clientId"
 import type { ServerMessage } from "@/types/messages"
 import { WebSocket } from "partysocket"
+import { getPlayerName } from "@/lib/playerName"
 
 export function useRoomSession(roomId: string) {
   const { t } = useTranslation("room")
@@ -18,6 +19,9 @@ export function useRoomSession(roomId: string) {
     host: `${window.location.hostname}:1999`,
     room: roomId,
     id: getClientId(),
+    query: {
+      name: getPlayerName() ?? "",
+    },
     onMessage(event) {
       try {
         const msg = JSON.parse(event.data) as ServerMessage

--- a/src/lib/playerName.ts
+++ b/src/lib/playerName.ts
@@ -1,0 +1,17 @@
+const KEY = "playerName"
+
+export function getPlayerName(): string | null {
+  try {
+    return localStorage.getItem(KEY)
+  } catch {
+    return null
+  }
+}
+
+export function setPlayerName(name: string): void {
+  try {
+    localStorage.setItem(KEY, name.trim())
+  } catch (e) {
+    console.error(e)
+  }
+}

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -1,4 +1,5 @@
 {
   "or": "or",
-  "and": "and"
+  "and": "and",
+  "nameInput": "Your name"
 }

--- a/src/pages/Game.tsx
+++ b/src/pages/Game.tsx
@@ -140,7 +140,7 @@ function GameSessionView({ roomId }: { roomId: string }) {
                     p.id === myId ? "font-medium" : "text-muted-foreground"
                   }
                 >
-                  {p.id}
+                  {p.name}
                 </span>
                 <span>{gameOver.scores[p.id] ?? 0}</span>
               </div>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -21,7 +21,7 @@ export default function Home() {
   return (
     <div className="flex flex-col gap-4">
       <Input
-        placeholder="Your name"
+        placeholder={t("nameInput")}
         value={name}
         onChange={handleNameChange}
         maxLength={20}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,16 +1,34 @@
 import CreateRoomButton from "@/components/room/CreateRoomButton"
 import JoinRoomInput from "@/components/room/JoinRoomInput"
 import { Divider } from "@/components/ui/divider"
+import { Input } from "@/components/ui/input"
+import { getPlayerName, setPlayerName } from "@/lib/playerName"
+import { useState } from "react"
 import { useTranslation } from "react-i18next"
 
 export default function Home() {
   const { t } = useTranslation("common")
+  const [name, setName] = useState(getPlayerName() ?? "")
+
+  const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const val = e.target.value
+    setName(val)
+    if (val.trim()) setPlayerName(val.trim())
+  }
+
+  const ready = name.trim().length > 0
 
   return (
     <div className="flex flex-col gap-4">
-      <CreateRoomButton />
+      <Input
+        placeholder="Your name"
+        value={name}
+        onChange={handleNameChange}
+        maxLength={20}
+      />
+      <CreateRoomButton disabled={!ready} />
       <Divider label={t("or")} />
-      <JoinRoomInput />
+      <JoinRoomInput disabled={!ready} />
     </div>
   )
 }

--- a/src/types/room.ts
+++ b/src/types/room.ts
@@ -1,5 +1,6 @@
 export interface Player {
   id: string
+  name: string
   ready: boolean
   connected: boolean
   score: number


### PR DESCRIPTION
## What
Players enter a display name before creating or joining a room; names are shown everywhere instead of UUIDs.

## Why
Raw UUIDs were shown in the lobby, scoreboard, and winner screen, making it impossible to tell players apart.

## How
- Name is persisted in `localStorage` via `src/lib/playerName.ts` and sent to the server as a `?name=` query param on WebSocket connect
- `party/lib/types.ts` and `src/types/room.ts` both gain a `name` field on `Player`; `toPublicPlayer` broadcasts it automatically
- `Home.tsx` gates `CreateRoomButton` and `JoinRoomInput` behind a non-empty name input using the existing `"common"` i18n namespace
- `PlayerItem`, `ScoreBoardItem`, and the winner screen in `Game.tsx` render `player.name` instead of `player.id`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **src/lib/playerName.ts** – New localStorage helper module with `getPlayerName()` and `setPlayerName()` functions for persisting player name
- **party/lib/types.ts** – Added `name: string` field to Player interface
- **src/types/room.ts** – Added `name: string` field to Player interface
- **party/index.ts** – Server extracts player name from WebSocket query parameter and stores it in player state
- **src/hooks/room/useRoomSession.ts** – Transmit player name via `query.name` parameter on WebSocket connection
- **src/hooks/game/useGameSession.ts** – Transmit player name via `query.name` parameter on WebSocket connection
- **src/pages/Home.tsx** – Add name input field; gate CreateRoomButton and JoinRoomInput behind non-empty name validation; initialize name from localStorage
- **src/components/room/CreateRoomButton.tsx** – Accept optional `disabled` prop to enable/disable button
- **src/components/room/JoinRoomInput.tsx** – Accept optional `disabled` prop to enable/disable join button
- **src/components/room/PlayerItem.tsx** – Display `player.name` instead of `player.id`
- **src/components/game/ScoreBoardItem.tsx** – Display `player.name` instead of `player.id`
- **src/pages/Game.tsx** – Display `player.name` instead of `player.id` in game-over winner screen
- **src/locales/en/common.json** – Add `nameInput` i18n key with "Your name" value

<!-- end of auto-generated comment: release notes by coderabbit.ai -->