### PR TITLE
Hide points during active drag on tile

### DIFF
--- a/src/pages/Game.tsx
+++ b/src/pages/Game.tsx
@@ -189,7 +189,7 @@ function GameSessionView({ roomId }: { roomId: string }) {
       </RoomLayout>
 
       <DragOverlay dropAnimation={null}>
-        {activeTile ? <Tile tile={activeTile} /> : null}
+        {activeTile ? <Tile tile={activeTile} hidePoints /> : null}
       </DragOverlay>
     </DndContext>
   )


### PR DESCRIPTION
## What
Added `hidePoints` prop to `Tile` in the `DragOverlay` to hide point values while dragging.

## Why
Tile point values were displaying during drag and on the board, when they should only appear in the rack.

## How
- Pass `hidePoints` prop to `<Tile>` in `DragOverlay` (`src/pages/Game.tsx:180`)
- `BoardCell` already hides points on placed tiles
- Rack tiles render without `hidePoints`, so points display naturally