### PR TITLE
Introduce GameState to manage game logic

### DIFF
--- a/party/index.ts
+++ b/party/index.ts
@@ -156,6 +156,9 @@ export default class Server implements Party.Server {
     }
 
     const player = this.gameState.players[sender.id]
+    if (!player) {
+      return
+    }
     this.room
       .getConnection(sender.id)
       ?.send(JSON.stringify({ type: "RACK_STATE", tiles: player.rack }))

--- a/party/index.ts
+++ b/party/index.ts
@@ -1,6 +1,6 @@
 import type * as Party from "partykit/server"
-import { BOARD_SIZE, MAX_PLAYERS, MIN_PLAYERS, RACK_SIZE } from "./constants"
-import { buildBag, drawTiles, refillRack, shuffleBag } from "./lib/bag"
+import { GameState } from "./lib/gameState"
+import { toPublicPlayer, type Tile } from "./lib/types"
 import {
   broadcastBoardState,
   broadcastGameOver,
@@ -12,119 +12,78 @@ import {
   sendRoomFull,
   sendSubmitError,
 } from "./lib/messages"
-import {
-  advanceToNextConnectedPlayer,
-  findFirstConnectedPlayer,
-} from "./lib/turns"
-import {
-  isPlacement,
-  toPublicPlayer,
-  type Player,
-  type Tile,
-} from "./lib/types"
-import { validatePlacements } from "./lib/validation"
 
 export default class Server implements Party.Server {
-  players: Record<string, Player> = {}
-  bag: Tile[] = []
-  gameStarted = false
-  gameOver = false
-  winnerIds: string[] = []
-  playerOrder: string[] = []
-  currentTurn: string | null = null
-  board: (Tile | null)[][] = Array.from({ length: BOARD_SIZE }, () =>
-    Array.from({ length: BOARD_SIZE }, () => null)
-  )
+  gameState = new GameState()
 
   constructor(readonly room: Party.Room) {}
 
   onConnect(conn: Party.Connection) {
-    const isReconnect = !!this.players[conn.id]
+    const url = new URL(conn.uri)
+    const name = url.searchParams.get("name")?.trim() || conn.id
 
-    if (!isReconnect) {
-      if (this.gameStarted || Object.keys(this.players).length >= MAX_PLAYERS) {
-        sendRoomFull(conn)
-        conn.close()
-        return
-      }
-      this.playerOrder.push(conn.id)
-      const url = new URL(conn.uri)
-      const name = url.searchParams.get("name")?.trim() || conn.id
+    const result = this.gameState.playerConnect(conn.id, name)
 
-      this.players[conn.id] = {
-        id: conn.id,
-        name,
-        ready: false,
-        rack: [],
-        connected: true,
-        score: 0,
-      }
+    if (result.isRoomFull) {
+      sendRoomFull(conn)
+      conn.close()
+      return
     }
 
-    const player = this.players[conn.id]
-    player.connected = true
+    const player = this.gameState.players[conn.id]
+    if (player && player.rack.length > 0) {
+      sendRack(conn, player.rack)
+    }
 
-    if (player.rack.length > 0) sendRack(conn, player.rack)
+    if (!result.isNewPlayer && this.gameState.gameStarted) {
+      const reconnectResult = this.gameState.handleReconnect(conn.id)
 
-    if (isReconnect && this.gameStarted) {
-      if (this.gameOver) {
+      if (reconnectResult.gameOver) {
         conn.send(
           JSON.stringify({
             type: "GAME_OVER",
-            winnerIds: this.winnerIds,
-            scores: this.getScores(),
+            winnerIds: reconnectResult.winnerIds,
+            scores: reconnectResult.scores,
           })
         )
+        if (reconnectResult.currentTurn) {
+          broadcastTurnChange(
+            this.room,
+            reconnectResult.currentTurn,
+            reconnectResult.scores
+          )
+        }
         return
       }
 
-      const scores = this.getScores()
-      if (!this.players[this.currentTurn ?? ""]?.connected) {
-        this.currentTurn = advanceToNextConnectedPlayer(
-          this.playerOrder,
-          this.players,
-          this.currentTurn
-        )
-        broadcastTurnChange(this.room, this.currentTurn, scores)
-      }
-      sendGameStart(conn, this.currentTurn, scores)
-      this.sendBoardState(conn, this.board)
+      sendGameStart(conn, reconnectResult.currentTurn, reconnectResult.scores)
+      this.sendBoardState(conn, reconnectResult.board)
+      broadcastTurnChange(
+        this.room,
+        reconnectResult.currentTurn,
+        reconnectResult.scores
+      )
     }
 
     broadcastRoomState(
       this.room,
-      Object.values(this.players).map(toPublicPlayer)
+      Object.values(this.gameState.players).map(toPublicPlayer)
     )
   }
 
   onClose(conn: Party.Connection) {
-    const player = this.players[conn.id]
+    this.gameState.playerDisconnect(conn.id)
 
-    if (this.gameStarted) {
-      if (player) {
-        player.connected = false
-        if (this.currentTurn === conn.id) {
-          this.currentTurn = advanceToNextConnectedPlayer(
-            this.playerOrder,
-            this.players,
-            this.currentTurn
-          )
-          const scores = this.getScores()
-          broadcastTurnChange(this.room, this.currentTurn, scores)
-        }
-        broadcastRoomState(
-          this.room,
-          Object.values(this.players).map(toPublicPlayer)
-        )
+    if (this.gameState.gameStarted) {
+      const scores = this.getScores()
+      if (this.gameState.currentTurn) {
+        broadcastTurnChange(this.room, this.gameState.currentTurn, scores)
       }
-      return
     }
 
-    delete this.players[conn.id]
-    this.playerOrder = this.playerOrder.filter((id) => id !== conn.id)
     broadcastRoomState(
       this.room,
-      Object.values(this.players).map(toPublicPlayer)
+      Object.values(this.gameState.players).map(toPublicPlayer)
     )
   }
 
@@ -136,122 +95,80 @@ export default class Server implements Party.Server {
       return
     }
 
-    if (!this.players[sender.id] || typeof msg !== "object" || msg === null)
+    if (
+      !this.gameState.players[sender.id] ||
+      typeof msg !== "object" ||
+      msg === null
+    ) {
       return
+    }
 
     const action = msg as { type?: string; placements?: unknown }
 
     if (typeof action.type !== "string") return
 
-    if (action.type === "READY" || action.type === "UNREADY") {
-      this.handleReadyToggle(sender, action.type)
+    if (action.type === "READY") {
+      this.handleReadyToggle(sender, true)
+    } else if (action.type === "UNREADY") {
+      this.handleReadyToggle(sender, false)
     } else if (action.type === "SUBMIT_TURN") {
-      this.handleSubmitTurn(sender, action)
+      this.handleSubmitTurn(sender, action.placements)
     }
   }
 
-  startGame() {
-    if (this.gameStarted) return
-    this.gameStarted = true
+  private handleReadyToggle(sender: Party.Connection, ready: boolean) {
+    const result = this.gameState.toggleReady(sender.id, ready)
 
-    this.currentTurn = findFirstConnectedPlayer(this.playerOrder, this.players)
-    this.bag = shuffleBag(buildBag())
-
-    for (const id in this.players) {
-      const player = this.players[id]
-      const { drawn, remaining } = drawTiles(this.bag, RACK_SIZE)
-      this.bag = remaining
-      player.rack = drawn
-      const conn = this.room.getConnection(id)
-      if (conn) sendRack(conn, drawn)
+    if (result.shouldStartGame) {
+      broadcastGameStart(
+        this.room,
+        this.gameState.currentTurn,
+        this.getScores()
+      )
+      for (const id in this.gameState.players) {
+        const player = this.gameState.players[id]
+        const conn = this.room.getConnection(id)
+        if (conn) {
+          sendRack(conn, player.rack)
+        }
+      }
+    } else {
+      broadcastRoomState(
+        this.room,
+        Object.values(this.gameState.players).map(toPublicPlayer)
+      )
     }
-
-    broadcastGameStart(this.room, this.currentTurn, this.getScores())
   }
 
-  private handleSubmitTurn(
-    sender: Party.Connection,
-    msg: { placements?: unknown }
-  ) {
-    if (sender.id !== this.currentTurn) return
-    if (this.gameOver) return
+  private handleSubmitTurn(sender: Party.Connection, placements: unknown) {
+    if (sender.id !== this.gameState.currentTurn) {
+      return
+    }
+    if (this.gameState.gameOver) {
+      return
+    }
 
-    const player = this.players[sender.id]
-    const placements = Array.isArray(msg.placements)
-      ? msg.placements.filter(isPlacement)
-      : []
+    const result = this.gameState.submitTurn(sender.id, placements)
 
-    const result = validatePlacements(placements, this.board)
-    if (!result.valid) {
+    if (!result.success) {
       sendSubmitError(sender, result.error)
       return
     }
 
-    for (const { row, col, rackIndex } of placements) {
-      this.board[row][col] = player.rack[rackIndex]
-    }
-
-    const turnScore = placements.reduce((sum, { rackIndex }) => {
-      return sum + (player.rack[rackIndex]?.points ?? 0)
-    }, 0)
-    player.score += turnScore
-
-    const indices = this.getValidatedRackIndices(msg.placements)
-
-    this.removeTilesFromRack(player, indices)
-
-    const { rack, bag } = refillRack(player.rack, this.bag)
-    player.rack = rack
-    this.bag = bag
-
+    const player = this.gameState.players[sender.id]
     this.room
       .getConnection(sender.id)
-      ?.send(JSON.stringify({ type: "RACK_STATE", tiles: rack }))
+      ?.send(JSON.stringify({ type: "RACK_STATE", tiles: player.rack }))
 
-    this.checkGameOver(player)
-    broadcastBoardState(this.room, this.board)
-    if (this.gameOver) return
+    broadcastBoardState(this.room, this.gameState.board)
 
-    this.currentTurn = advanceToNextConnectedPlayer(
-      this.playerOrder,
-      this.players,
-      this.currentTurn
-    )
+    if (this.gameState.gameOver) {
+      broadcastGameOver(this.room, this.gameState.winnerIds, this.getScores())
+      return
+    }
+
     const scores = this.getScores()
-    broadcastTurnChange(this.room, this.currentTurn, scores)
-  }
-
-  private getValidatedRackIndices(placements: unknown): number[] {
-    if (!Array.isArray(placements)) return []
-
-    // Deduplication is necessary because a player might accidentally
-    // submit the same rack index twice in a single turn.
-    return [
-      ...new Set(placements.filter(isPlacement).map((p) => p.rackIndex)),
-    ].sort((a, b) => b - a)
-  }
-
-  private handleReadyToggle(
-    sender: Party.Connection,
-    type: "READY" | "UNREADY"
-  ) {
-    this.players[sender.id].ready = type === "READY"
-    const list = Object.values(this.players)
-    const allReady = list.length >= MIN_PLAYERS && list.every((p) => p.ready)
-
-    if (allReady) {
-      this.startGame()
-    } else {
-      broadcastRoomState(this.room, list.map(toPublicPlayer))
-    }
-  }
-
-  private removeTilesFromRack(player: Player, indices: number[]) {
-    for (const index of indices) {
-      if (index >= 0 && index < player.rack.length) {
-        player.rack.splice(index, 1)
-      }
-    }
+    broadcastTurnChange(this.room, this.gameState.currentTurn, scores)
   }
 
   private sendBoardState(conn: Party.Connection, board: (Tile | null)[][]) {
@@ -259,19 +176,10 @@ export default class Server implements Party.Server {
   }
 
   private getScores(): Record<string, number> {
-    return Object.fromEntries(
-      Object.entries(this.players).map(([id, p]) => [id, p.score])
-    )
-  }
-
-  private checkGameOver(player: Player) {
-    if (this.bag.length !== 0 || player.rack.length !== 0) return
-    this.gameOver = true
-    const scores = this.getScores()
-    const maxScore = Math.max(...Object.values(scores))
-    this.winnerIds = Object.entries(scores)
-      .filter(([, s]) => s === maxScore)
-      .map(([id]) => id)
-    broadcastGameOver(this.room, this.winnerIds, scores)
+    const scores: Record<string, number> = {}
+    for (const [id, player] of Object.entries(this.gameState.players)) {
+      scores[id] = player.score
+    }
+    return scores
   }
 }

--- a/party/lib/gameState.ts
+++ b/party/lib/gameState.ts
@@ -83,7 +83,16 @@ export class GameState {
   }
 
   toggleReady(playerId: string, ready: boolean): ToggleReadyResult {
-    this.players[playerId].ready = ready
+    const player = this.players[playerId]
+    if (!player) {
+      return { shouldStartGame: false }
+    }
+
+    if (this.gameStarted) {
+      return { shouldStartGame: false }
+    }
+
+    player.ready = ready
     const list = Object.values(this.players)
     const shouldStartGame =
       list.length >= MIN_PLAYERS && list.every((p) => p.ready)
@@ -105,6 +114,18 @@ export class GameState {
     const result = validatePlacements(validatedPlacements, this.board)
     if (!result.valid) {
       return { success: false, error: result.error }
+    }
+
+    // Validate rackIndex bounds and uniqueness
+    const rackIndices = new Set<number>()
+    for (const { rackIndex } of validatedPlacements) {
+      if (rackIndex < 0 || rackIndex >= player.rack.length) {
+        return { success: false, error: "OUT_OF_BOUNDS" }
+      }
+      if (rackIndices.has(rackIndex)) {
+        return { success: false, error: "DUPLICATE_COORDINATE" }
+      }
+      rackIndices.add(rackIndex)
     }
 
     for (const { row, col, rackIndex } of validatedPlacements) {

--- a/party/lib/gameState.ts
+++ b/party/lib/gameState.ts
@@ -1,0 +1,219 @@
+import { BOARD_SIZE, MAX_PLAYERS, MIN_PLAYERS, RACK_SIZE } from "../constants"
+import { buildBag, drawTiles, refillRack, shuffleBag } from "./bag"
+import { isPlacement, type Player, type Tile } from "./types"
+import { advanceToNextConnectedPlayer, findFirstConnectedPlayer } from "./turns"
+import { SubmitErrorCode, validatePlacements } from "./validation"
+
+export interface PlayerConnectResult {
+  isNewPlayer: boolean
+  isRoomFull: boolean
+}
+
+export interface ToggleReadyResult {
+  shouldStartGame: boolean
+}
+
+export type SubmitTurnResult =
+  | { success: true; turnScore: number }
+  | { success: false; error: SubmitErrorCode }
+
+export interface HandleReconnectResult {
+  gameOver: boolean
+  currentTurn: string | null
+  scores: Record<string, number>
+  board: (Tile | null)[][]
+  winnerIds: string[]
+}
+
+export class GameState {
+  players: Record<string, Player> = {}
+  board: (Tile | null)[][] = Array.from({ length: BOARD_SIZE }, () =>
+    Array.from({ length: BOARD_SIZE }, () => null)
+  )
+  bag: Tile[] = []
+  gameStarted = false
+  gameOver = false
+  winnerIds: string[] = []
+  playerOrder: string[] = []
+  currentTurn: string | null = null
+
+  playerConnect(playerId: string, playerName: string): PlayerConnectResult {
+    const isNewPlayer = !this.players[playerId]
+
+    if (isNewPlayer) {
+      if (this.gameStarted || Object.keys(this.players).length >= MAX_PLAYERS) {
+        return { isNewPlayer: true, isRoomFull: true }
+      }
+      this.playerOrder.push(playerId)
+      this.players[playerId] = {
+        id: playerId,
+        name: playerName,
+        ready: false,
+        rack: [],
+        connected: true,
+        score: 0,
+      }
+    } else {
+      const player = this.players[playerId]
+      player.connected = true
+    }
+
+    return { isNewPlayer, isRoomFull: false }
+  }
+
+  playerDisconnect(playerId: string): void {
+    const player = this.players[playerId]
+
+    if (this.gameStarted) {
+      if (player) {
+        player.connected = false
+        if (this.currentTurn === playerId) {
+          this.currentTurn = advanceToNextConnectedPlayer(
+            this.playerOrder,
+            this.players,
+            this.currentTurn
+          )
+        }
+      }
+      return
+    }
+
+    delete this.players[playerId]
+    this.playerOrder = this.playerOrder.filter((id) => id !== playerId)
+  }
+
+  toggleReady(playerId: string, ready: boolean): ToggleReadyResult {
+    this.players[playerId].ready = ready
+    const list = Object.values(this.players)
+    const shouldStartGame =
+      list.length >= MIN_PLAYERS && list.every((p) => p.ready)
+
+    if (shouldStartGame) {
+      this.startGame()
+    }
+
+    return { shouldStartGame }
+  }
+
+  submitTurn(playerId: string, placements: unknown): SubmitTurnResult {
+    const player = this.players[playerId]
+
+    const validatedPlacements = Array.isArray(placements)
+      ? placements.filter(isPlacement)
+      : []
+
+    const result = validatePlacements(validatedPlacements, this.board)
+    if (!result.valid) {
+      return { success: false, error: result.error }
+    }
+
+    for (const { row, col, rackIndex } of validatedPlacements) {
+      this.board[row][col] = player.rack[rackIndex]
+    }
+
+    const turnScore = validatedPlacements.reduce((sum, { rackIndex }) => {
+      return sum + (player.rack[rackIndex]?.points ?? 0)
+    }, 0)
+    player.score += turnScore
+
+    const indices = this.getValidatedRackIndices(placements)
+    this.removeTilesFromRack(player, indices)
+
+    const { rack, bag } = refillRack(player.rack, this.bag)
+    player.rack = rack
+    this.bag = bag
+
+    this.checkGameOver(player)
+
+    if (!this.gameOver) {
+      this.advanceTurn()
+    }
+
+    return { success: true, turnScore }
+  }
+
+  handleReconnect(_playerId: string): HandleReconnectResult {
+    const scores = this.getScores()
+
+    if (this.gameOver) {
+      return {
+        gameOver: true,
+        currentTurn: null,
+        scores,
+        board: this.board,
+        winnerIds: this.winnerIds,
+      }
+    }
+
+    if (!this.players[this.currentTurn ?? ""]?.connected) {
+      this.currentTurn = advanceToNextConnectedPlayer(
+        this.playerOrder,
+        this.players,
+        this.currentTurn
+      )
+    }
+
+    return {
+      gameOver: false,
+      currentTurn: this.currentTurn,
+      scores,
+      board: this.board,
+      winnerIds: [],
+    }
+  }
+
+  startGame(): void {
+    if (this.gameStarted) return
+    this.gameStarted = true
+
+    this.currentTurn = findFirstConnectedPlayer(this.playerOrder, this.players)
+    this.bag = shuffleBag(buildBag())
+
+    for (const id in this.players) {
+      const player = this.players[id]
+      const { drawn, remaining } = drawTiles(this.bag, RACK_SIZE)
+      this.bag = remaining
+      player.rack = drawn
+    }
+  }
+
+  private advanceTurn(): void {
+    this.currentTurn = advanceToNextConnectedPlayer(
+      this.playerOrder,
+      this.players,
+      this.currentTurn
+    )
+  }
+
+  private getValidatedRackIndices(placements: unknown): number[] {
+    if (!Array.isArray(placements)) return []
+
+    return [
+      ...new Set(placements.filter(isPlacement).map((p) => p.rackIndex)),
+    ].sort((a, b) => b - a)
+  }
+
+  private removeTilesFromRack(player: Player, indices: number[]): void {
+    for (const index of indices) {
+      if (index >= 0 && index < player.rack.length) {
+        player.rack.splice(index, 1)
+      }
+    }
+  }
+
+  private getScores(): Record<string, number> {
+    return Object.fromEntries(
+      Object.entries(this.players).map(([id, p]) => [id, p.score])
+    )
+  }
+
+  private checkGameOver(player: Player): void {
+    if (this.bag.length !== 0 || player.rack.length !== 0) return
+    this.gameOver = true
+    const scores = this.getScores()
+    const maxScore = Math.max(...Object.values(scores))
+    this.winnerIds = Object.entries(scores)
+      .filter(([, s]) => s === maxScore)
+      .map(([id]) => id)
+  }
+}


### PR DESCRIPTION
## What
Refactor the PartyKit server state logic out of the core `Server` class into a new dedicated `GameState` management class.

## Why
This separation decouples network/connection handling from core game rules and state transitions, improving testability and code maintainability.

## How
* Created a standalone `GameState` class in `party/lib/gameState.ts` to fully encapsulate players, board state, tile bag handling, and game loop transitions.
* Extracted state-mutating operations like connections, disconnects, turn submissions, and readiness toggles into explicit, return-typed methods on `GameState`.
* Streamlined `party/index.ts` to act primarily as a network orchestrator that passes incoming multi-player events directly down to `this.gameState` and handles outward broadcasting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**party/index.ts**
- Removed public fields: `players`, `bag`, `gameStarted`, `gameOver`, `winnerIds`, `playerOrder`, `currentTurn`, `board`
- Added public field: `gameState` instance
- Removed `startGame()` method
- Refactored `onConnect` to delegate to `gameState.playerConnect()` and `gameState.handleReconnect()`
- Refactored `onClose` to delegate to `gameState.playerDisconnect()`
- Refactored `onMessage` to route to `gameState.toggleReady()` and `gameState.submitTurn()`
- Removed in-file turn management, placement validation, scoring, and rack handling logic
- Server now acts as network orchestrator forwarding events to GameState

**party/lib/gameState.ts (new file)**
- New `GameState` class encapsulating game rules and state transitions
- Public fields: `players`, `board`, `bag`, `gameStarted`, `gameOver`, `winnerIds`, `playerOrder`, `currentTurn`
- Public methods: `playerConnect()`, `playerDisconnect()`, `toggleReady()`, `submitTurn()`, `handleReconnect()`, `startGame()`
- Manages player records (id, name, ready, connected, rack, score)
- Handles player capacity and max-player enforcement
- Implements turn advancement on disconnect and between normal turns
- Implements readiness-based game start
- Implements turn submission with placement validation, board/rack/score updates
- Implements reconnect response logic (final game state vs turn advancement)
- Private helpers: turn advancement, rack index validation, tile removal, score computation, game-over detection with winner determination

**Intent:** Decouple network/connection handling from core game rules and state transitions to improve testability and maintainability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->