### PR TITLE
Bump version to 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mova",
   "private": true,
-  "version": "0.0.2",
+  "version": "1.0.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## What
Bump `package.json` version from `0.0.2` to `1.0.0`.

## Why
Marks the official v1 release of Mova.