### PR TITLE
Feat/add skip turn action

### DIFF
--- a/party/index.ts
+++ b/party/index.ts
@@ -113,6 +113,8 @@ export default class Server implements Party.Server {
       this.handleReadyToggle(sender, false)
     } else if (action.type === "SUBMIT_TURN") {
       this.handleSubmitTurn(sender, action.placements)
+    } else if (action.type === "SKIP_TURN") {
+      this.handleSkipTurn(sender)
     }
   }
 
@@ -184,5 +186,16 @@ export default class Server implements Party.Server {
       scores[id] = player.score
     }
     return scores
+  }
+
+  private handleSkipTurn(sender: Party.Connection) {
+    if (sender.id !== this.gameState.currentTurn || this.gameState.gameOver) {
+      return
+    }
+
+    this.gameState.skipTurn()
+
+    const scores = this.getScores()
+    broadcastTurnChange(this.room, this.gameState.currentTurn, scores)
   }
 }

--- a/party/lib/gameState.ts
+++ b/party/lib/gameState.ts
@@ -237,4 +237,9 @@ export class GameState {
       .filter(([, s]) => s === maxScore)
       .map(([id]) => id)
   }
+
+  skipTurn(): void {
+    if (this.gameOver) return
+    this.advanceTurn()
+  }
 }

--- a/src/locales/en/game.json
+++ b/src/locales/en/game.json
@@ -39,9 +39,21 @@
         "title": "Connection lost",
         "description": "The connection was interrupted. You have been returned to the home screen."
       }
+    },
+    "skip": {
+      "failed": {
+        "title": "Failed to skip turn",
+        "description": "An error occurred while skipping your turn."
+      }
     }
   },
   "labels": {
-    "you": "You"
+    "you": "You",
+    "gameOver": {
+      "tie": "It's a tie!",
+      "win": "You win!",
+      "lose": "You lose!",
+      "goHome": "Go Home"
+    }
   }
 }

--- a/src/pages/Game.tsx
+++ b/src/pages/Game.tsx
@@ -18,7 +18,7 @@ import {
   type DragEndEvent,
   type DragStartEvent,
 } from "@dnd-kit/core"
-import { Check, Trash } from "lucide-react"
+import { Check, SkipForward, Trash } from "lucide-react"
 import { useEffect, useRef, useState } from "react"
 import { useNavigate, useParams } from "react-router"
 
@@ -181,6 +181,14 @@ function GameSessionView({ roomId }: { roomId: string }) {
             <Trash />
           </Button>
           <Rack tiles={rack} disabled={!isMyTurn} />
+          <Button
+            variant="secondary"
+            disabled={!isMyTurn}
+            onClick={() => send({ type: "SKIP_TURN" })}
+            aria-label="Skip turn"
+          >
+            <SkipForward />
+          </Button>
           <Button
             variant="secondary"
             disabled={!isMyTurn || Object.keys(assignments).length === 0}

--- a/src/pages/Game.tsx
+++ b/src/pages/Game.tsx
@@ -21,8 +21,11 @@ import {
 import { Check, SkipForward, Trash } from "lucide-react"
 import { useEffect, useRef, useState } from "react"
 import { useNavigate, useParams } from "react-router"
+import { useTranslation } from "react-i18next"
+import { toast } from "sonner"
 
 function GameSessionView({ roomId }: { roomId: string }) {
+  const { t } = useTranslation("game")
   const navigate = useNavigate()
   const {
     tiles,
@@ -117,6 +120,21 @@ function GameSessionView({ roomId }: { roomId: string }) {
     send({ type: "SUBMIT_TURN", placements })
   }
 
+  const handleSkipTurn = () => {
+    try {
+      send({ type: "SKIP_TURN" })
+      returnAll()
+    } catch (error) {
+      console.error("Failed to skip turn:", error)
+      toast.error(t("errors.skip.failed.title", "Failed to skip turn"), {
+        description: t(
+          "errors.skip.failed.description",
+          "An error occurred while skipping your turn."
+        ),
+      })
+    }
+  }
+
   if (gameOver) {
     const myId = getClientId()
     const isWinner = gameOver.winnerIds.includes(myId)
@@ -126,10 +144,10 @@ function GameSessionView({ roomId }: { roomId: string }) {
       <div className="flex flex-col items-center justify-center gap-6">
         <h1 className="font-heading text-2xl font-medium">
           {isTie && isWinner
-            ? "It's a tie!"
+            ? t("labels.gameOver.tie")
             : isWinner
-              ? "You win!"
-              : "You lose!"}
+              ? t("labels.gameOver.win")
+              : t("labels.gameOver.lose")}
         </h1>
         <div className="flex flex-col gap-1">
           {[...players]
@@ -150,7 +168,9 @@ function GameSessionView({ roomId }: { roomId: string }) {
               </div>
             ))}
         </div>
-        <Button onClick={() => navigate("/")}>Go Home</Button>
+        <Button onClick={() => navigate("/")}>
+          {t("labels.gameOver.goHome")}
+        </Button>
       </div>
     )
   }
@@ -184,11 +204,12 @@ function GameSessionView({ roomId }: { roomId: string }) {
           <Button
             variant="secondary"
             disabled={!isMyTurn}
-            onClick={() => send({ type: "SKIP_TURN" })}
+            onClick={handleSkipTurn}
             aria-label="Skip turn"
           >
             <SkipForward />
           </Button>
+
           <Button
             variant="secondary"
             disabled={!isMyTurn || Object.keys(assignments).length === 0}

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -26,3 +26,4 @@ export type ClientMessage =
       type: "SUBMIT_TURN"
       placements: { rackIndex: number; row: number; col: number }[]
     }
+  | { type: "SKIP_TURN" }


### PR DESCRIPTION
## What
Updated the skip turn mechanism and localized UI messages in `src/pages/Game.tsx`.

## Why
The skip turn button did not clear local tile assignments, and several UI components contained hardcoded strings instead of using the existing localization system.

## How
- Implemented `handleSkipTurn` in `GameSessionView` to send the skip signal and clear local state using `returnAll`, wrapped in a `try...catch` block.
- Updated the skip turn `Button` to use the new handler.
- Integrated `useTranslation` to localize `gameOver` view messages and error feedback, updating `src/locales/en/game.json` accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **party/index.ts** — Added `SKIP_TURN` message handler that verifies turn ownership and game state, then advances turn and broadcasts changes
- **party/lib/gameState.ts** — Added `skipTurn()` method to advance to next connected player (no-op if game over)
- **src/pages/Game.tsx** — Added `handleSkipTurn` handler to send skip signal and clear local tiles; integrated `useTranslation` for game-over messaging
- **src/types/messages.ts** — Extended `ClientMessage` union with `{ type: "SKIP_TURN" }` variant
- **src/locales/en/game.json** — Added error messages for failed skip turns and localized game-over UI labels (`tie`, `win`, `lose`, `goHome`)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->