### PR TITLE
Add dictionary support and word validation helpers

### DIFF
--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -1,0 +1,1 @@
+declare module "pf-sowpods"

--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -1,1 +1,4 @@
-declare module "pf-sowpods"
+declare module "pf-sowpods" {
+  const sowpods: string[]
+  export = sowpods
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "mova",
-  "version": "0.0.2",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mova",
-      "version": "0.0.2",
+      "version": "1.2.0",
       "dependencies": {
         "@base-ui/react": "^1.3.0",
         "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/utilities": "^3.2.2",
         "@fontsource-variable/ibm-plex-sans": "^5.2.8",
         "@tailwindcss/vite": "^4.2.1",
         "class-variance-authority": "^0.7.1",
@@ -19,6 +20,7 @@
         "lucide-react": "^1.7.0",
         "next-themes": "^0.4.6",
         "partysocket": "1.1.16",
+        "pf-sowpods": "^1.2.1",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-i18next": "^17.0.2",
@@ -6984,6 +6986,12 @@
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
       "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pf-sowpods": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/pf-sowpods/-/pf-sowpods-1.2.1.tgz",
+      "integrity": "sha512-6B8dR2jlhYfXKSx5VVmlfDfXe4dGyK6ieWzVElgEvZVFXoq8pil0aq8K28kzbltoIa+Y26QGk0MhfJOdUli/Ww==",
       "license": "MIT"
     },
     "node_modules/picocolors": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mova",
   "private": true,
-  "version": "1.1.0",
+  "version": "1.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -27,6 +27,7 @@
     "lucide-react": "^1.7.0",
     "next-themes": "^0.4.6",
     "partysocket": "1.1.16",
+    "pf-sowpods": "^1.2.1",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-i18next": "^17.0.2",

--- a/party/index.ts
+++ b/party/index.ts
@@ -12,11 +12,6 @@ import {
   sendRoomFull,
   sendSubmitError,
 } from "./lib/messages"
-import {
-  isValidWord,
-  isValidWithBlank,
-  validatePlacements,
-} from "./lib/validation"
 
 export default class Server implements Party.Server {
   gameState = new GameState()

--- a/party/index.ts
+++ b/party/index.ts
@@ -12,6 +12,11 @@ import {
   sendRoomFull,
   sendSubmitError,
 } from "./lib/messages"
+import {
+  isValidWord,
+  isValidWithBlank,
+  validatePlacements,
+} from "./lib/validation"
 
 export default class Server implements Party.Server {
   gameState = new GameState()

--- a/party/lib/validation.ts
+++ b/party/lib/validation.ts
@@ -24,10 +24,12 @@ const dictionary = new Set(sowpods.map((w: string) => w.toUpperCase()))
 const blankCache = new Map<string, boolean>()
 
 export function isValidWord(word: string): boolean {
+  if (!word) return false
   return dictionary.has(word.toUpperCase())
 }
 
 export function isValidWithBlank(word: string): boolean {
+  if (!word) return false
   const normalized = word.toUpperCase()
   if (blankCache.has(normalized)) {
     return blankCache.get(normalized)!

--- a/party/lib/validation.ts
+++ b/party/lib/validation.ts
@@ -1,3 +1,4 @@
+import sowpods from "pf-sowpods"
 import { Tile } from "./types"
 
 type Placement = { rackIndex: number; row: number; col: number }
@@ -18,6 +19,43 @@ export type SubmitErrorCode = Extract<
   ValidationResult,
   { valid: false }
 >["error"]
+
+const dictionary = new Set(sowpods.map((w: string) => w.toUpperCase()))
+const blankCache = new Map<string, boolean>()
+
+export function isValidWord(word: string): boolean {
+  return dictionary.has(word.toUpperCase())
+}
+
+export function isValidWithBlank(word: string): boolean {
+  const normalized = word.toUpperCase()
+  if (blankCache.has(normalized)) {
+    return blankCache.get(normalized)!
+  }
+
+  function canFormValidWord(currentWord: string): boolean {
+    const blankIndex = currentWord.indexOf("?")
+    if (blankIndex === -1) {
+      return dictionary.has(currentWord)
+    }
+
+    for (let i = 0; i < 26; i++) {
+      const char = String.fromCharCode(65 + i)
+      const nextWord =
+        currentWord.substring(0, blankIndex) +
+        char +
+        currentWord.substring(blankIndex + 1)
+      if (canFormValidWord(nextWord)) {
+        return true
+      }
+    }
+    return false
+  }
+
+  const isValid = canFormValidWord(normalized)
+  blankCache.set(normalized, isValid)
+  return isValid
+}
 
 export function validatePlacements(
   placements: Placement[],


### PR DESCRIPTION
## What
Installed `pf-sowpods` and implemented server-side word validation with support for blank tiles (wildcards).

## Why
To enable accurate, flexible word validation for the game that handles wildcards and improves performance via caching.

## How
- Added `pf-sowpods` dependency and created `party/lib/validation.ts` to centralize validation logic, ensuring adherence to the Single Responsibility Principle.
- Implemented `isValidWord` and `isValidWithBlank` in `party/lib/validation.ts` using a recursive approach for wildcard substitution and a `blankCache` `Map` for performance.
- Updated `party/index.ts` to import these validation helpers and removed manual dictionary management code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **declarations.d.ts**: Added TypeScript module declaration for `pf-sowpods` package
- **package.json**: Version bumped to 1.2.0; added `pf-sowpods` ^1.2.1 dependency
- **party/lib/validation.ts**: New validation module with:
  - `isValidWord()` - validates words against pf-sowpods dictionary
  - `isValidWithBlank()` - validates words with `?` wildcard tiles via recursive substitution (A-Z)
  - `blankCache` - performance cache for blank tile validation results
- **party/index.ts**: Imports validation helpers from `./lib/validation` for server-side word validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->