### PR TITLE
Add INVALID_WORD error to submission validation

### DIFF
--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -1,0 +1,4 @@
+declare module "pf-sowpods" {
+  const sowpods: string[]
+  export = sowpods
+}

--- a/party/lib/validation.ts
+++ b/party/lib/validation.ts
@@ -13,6 +13,8 @@ type ValidationResult =
         | "OUT_OF_BOUNDS"
         | "CELL_OCCUPIED"
         | "DUPLICATE_COORDINATE"
+        | "INVALID_WORD"
+      invalidWords?: string[]
     }
 export type SubmitErrorCode = Extract<
   ValidationResult,

--- a/party/lib/validation.ts
+++ b/party/lib/validation.ts
@@ -1,10 +1,10 @@
 import { Tile } from "./types"
 
 type Placement = { rackIndex: number; row: number; col: number }
-type ValidationResult =
-  | { valid: true }
-  | {
-      valid: false
+type BaseError = { valid: false }
+
+export type ValidationError =
+  | (BaseError & {
       error:
         | "NO_TILES"
         | "NOT_IN_LINE"
@@ -13,13 +13,13 @@ type ValidationResult =
         | "OUT_OF_BOUNDS"
         | "CELL_OCCUPIED"
         | "DUPLICATE_COORDINATE"
-        | "INVALID_WORD"
-      invalidWords?: string[]
-    }
-export type SubmitErrorCode = Extract<
-  ValidationResult,
-  { valid: false }
->["error"]
+    })
+  | (BaseError & {
+      error: "INVALID_WORD"
+      invalidWords: string[]
+    })
+
+export type ValidationResult = { valid: true } | ValidationError
 
 export function validatePlacements(
   placements: Placement[],

--- a/src/hooks/game/useGameSession.ts
+++ b/src/hooks/game/useGameSession.ts
@@ -60,7 +60,8 @@ export function useGameSession(roomId: string) {
             )
             const description = t(
               `errors.submit.${msg.error}.description`,
-              "An error occurred while submitting."
+              "An error occurred while submitting.",
+              { words: (msg.invalidWords ?? []).join(", ") }
             )
 
             toast.error(title, { description })

--- a/src/locales/en/game.json
+++ b/src/locales/en/game.json
@@ -28,6 +28,10 @@
       "DUPLICATE_COORDINATE": {
         "title": "Duplicate placement",
         "description": "You placed more than one tile in the same cell."
+      },
+      "INVALID_WORD": {
+        "title": "Invalid word",
+        "description": "The following words are not in our dictionary: {{words}}"
       }
     },
     "connection": {

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -15,7 +15,13 @@ export type ServerMessage =
   | { type: "BOARD_STATE"; board: Record<string, TileType> }
   | {
       type: "SUBMIT_ERROR"
-      error: "NO_TILES" | "NOT_IN_LINE" | "GAP_NOT_FILLED" | "NOT_CONNECTED"
+      error:
+        | "NO_TILES"
+        | "NOT_IN_LINE"
+        | "GAP_NOT_FILLED"
+        | "NOT_CONNECTED"
+        | "INVALID_WORD"
+      invalidWords?: string[]
     }
   | { type: "GAME_OVER"; winnerIds: string[]; scores: Record<string, number> }
 


### PR DESCRIPTION
## What
Added `INVALID_WORD` error code and `invalidWords[]` field to support reporting invalid words when players submit tiles.

## Why
Dictionary validation will need to communicate which words are invalid back to the client for display in error toasts.

## How
- `party/lib/validation.ts`: Added `INVALID_WORD` to error union and optional `invalidWords?: string[]` field to `ValidationResult`
- `src/types/messages.ts`: Added `INVALID_WORD` error code and `invalidWords?: string[]` to `SUBMIT_ERROR` message type
- `src/locales/en/game.json`: Added `INVALID_WORD` entry with `{{words}}` interpolation placeholder for locale string

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- **`party/lib/validation.ts`**: Added `INVALID_WORD` error code to `ValidationResult` union and optional `invalidWords?: string[]` field to expose invalid words from dictionary validation
- **`src/types/messages.ts`**: Extended `SUBMIT_ERROR` message type with `INVALID_WORD` error code and optional `invalidWords?: string[]` field to transmit invalid words to client
- **`src/locales/en/game.json`**: Added `INVALID_WORD` locale entry with `{{words}}` interpolation to display invalid words in user-facing error messages
<!-- end of auto-generated comment: release notes by coderabbit.ai -->