### PR TITLE
Add word extraction logic for board placements

### DIFF
--- a/party/lib/wordExtraction.ts
+++ b/party/lib/wordExtraction.ts
@@ -8,12 +8,19 @@ export function extractWordsFormed(
   board: Board,
   newTiles: Tile[]
 ): string[] {
-  if (placements.length === 0) return []
+  if (placements.length !== newTiles.length) return []
 
   // Used to prevent accidental mutation of the actual game state.
   const tempBoard = board.map((row) => [...row])
   placements.forEach((p, i) => {
-    tempBoard[p.row][p.col] = newTiles[i]
+    if (
+      p.row >= 0 &&
+      p.row < tempBoard.length &&
+      p.col >= 0 &&
+      p.col < tempBoard[p.row].length
+    ) {
+      tempBoard[p.row][p.col] = newTiles[i]
+    }
   })
 
   // A Set ensures we only return unique words, satisfying the requirement.

--- a/party/lib/wordExtraction.ts
+++ b/party/lib/wordExtraction.ts
@@ -77,7 +77,13 @@ function getWordAt(
   // as the placement might be in the middle of an existing sequence.
   let r = row
   let c = col
-  while (r - dx >= 0 && c - dy >= 0 && board[r - dx][c - dy] !== null) {
+  while (
+    r - dx >= 0 &&
+    r - dx < board.length &&
+    c - dy >= 0 &&
+    c - dy < board[r - dx].length &&
+    board[r - dx][c - dy] !== null
+  ) {
     r -= dx
     c -= dy
   }

--- a/party/lib/wordExtraction.ts
+++ b/party/lib/wordExtraction.ts
@@ -1,0 +1,84 @@
+import { Tile } from "./types"
+
+type Board = (Tile | null)[][]
+type Placement = { row: number; col: number }
+
+export function extractWordsFormed(
+  placements: Placement[],
+  board: Board,
+  newTiles: Tile[]
+): string[] {
+  if (placements.length === 0) return []
+
+  // Used to prevent accidental mutation of the actual game state.
+  const tempBoard = board.map((row) => [...row])
+  placements.forEach((p, i) => {
+    tempBoard[p.row][p.col] = newTiles[i]
+  })
+
+  // A Set ensures we only return unique words, satisfying the requirement.
+  const words = new Set<string>()
+
+  const isHorizontal = placements.every((p) => p.row === placements[0].row)
+  const isVertical = placements.every((p) => p.col === placements[0].col)
+
+  // Identify the primary word created by the move.
+  if (isHorizontal) {
+    const word = getWordAt(
+      tempBoard,
+      placements[0].row,
+      placements[0].col,
+      0,
+      1
+    )
+    // Rules dictate a word must be at least 2 letters long.
+    if (word.length >= 2) words.add(word)
+  } else if (isVertical) {
+    const word = getWordAt(
+      tempBoard,
+      placements[0].row,
+      placements[0].col,
+      1,
+      0
+    )
+    if (word.length >= 2) words.add(word)
+  }
+
+  // Identify any perpendicular words created by the newly placed tiles.
+  placements.forEach((p) => {
+    const dx = isHorizontal ? 1 : 0
+    const dy = isHorizontal ? 0 : 1
+    const word = getWordAt(tempBoard, p.row, p.col, dx, dy)
+    if (word.length >= 2) words.add(word)
+  })
+
+  return Array.from(words).map((w) => w.toUpperCase())
+}
+
+function getWordAt(
+  board: Board,
+  row: number,
+  col: number,
+  dx: number,
+  dy: number
+): string {
+  let word = ""
+
+  // Backtrack to find the true beginning of the word,
+  // as the placement might be in the middle of an existing sequence.
+  let r = row
+  let c = col
+  while (r - dx >= 0 && c - dy >= 0 && board[r - dx][c - dy] !== null) {
+    r -= dx
+    c -= dy
+  }
+
+  // Iterate forward to reconstruct the full sequence.
+  while (r < board.length && c < board[0].length && board[r][c] !== null) {
+    word += board[r][c]!.letter
+    r += dx
+    c += dy
+  }
+
+  return word
+}

--- a/party/lib/wordExtraction.ts
+++ b/party/lib/wordExtraction.ts
@@ -89,7 +89,13 @@ function getWordAt(
   }
 
   // Iterate forward to reconstruct the full sequence.
-  while (r < board.length && c < board[0].length && board[r][c] !== null) {
+  while (
+    r < board.length &&
+    board[r] &&
+    c >= 0 &&
+    c < board[r].length &&
+    board[r][c] !== null
+  ) {
     word += board[r][c]!.letter
     r += dx
     c += dy

--- a/party/lib/wordExtraction.ts
+++ b/party/lib/wordExtraction.ts
@@ -29,6 +29,8 @@ export function extractWordsFormed(
   const isHorizontal = placements.every((p) => p.row === placements[0].row)
   const isVertical = placements.every((p) => p.col === placements[0].col)
 
+  if (!isHorizontal && !isVertical) return []
+
   // Identify the primary word created by the move.
   if (isHorizontal) {
     const word = getWordAt(

--- a/party/lib/wordExtraction.ts
+++ b/party/lib/wordExtraction.ts
@@ -8,19 +8,26 @@ export function extractWordsFormed(
   board: Board,
   newTiles: Tile[]
 ): string[] {
-  if (placements.length !== newTiles.length) return []
+  if (placements.length === 0 || placements.length !== newTiles.length)
+    return []
 
   // Used to prevent accidental mutation of the actual game state.
   const tempBoard = board.map((row) => [...row])
+  // Validate all placements upfront. If any are out of bounds,
+  // reject the entire operation to prevent partial/invalid states.
+  const isAnyInvalid = placements.some(
+    (p) =>
+      p.row < 0 ||
+      p.row >= tempBoard.length ||
+      p.col < 0 ||
+      p.col >= tempBoard[p.row].length
+  )
+
+  if (isAnyInvalid) return []
+
+  // Process valid placements
   placements.forEach((p, i) => {
-    if (
-      p.row >= 0 &&
-      p.row < tempBoard.length &&
-      p.col >= 0 &&
-      p.col < tempBoard[p.row].length
-    ) {
-      tempBoard[p.row][p.col] = newTiles[i]
-    }
+    tempBoard[p.row][p.col] = newTiles[i]
   })
 
   // A Set ensures we only return unique words, satisfying the requirement.


### PR DESCRIPTION
## What
Created `party/lib/wordExtraction.ts` to identify and extract words formed by new tile placements.

## Why
This logic is necessary to determine which words are created on the board during a player's turn for scoring and validation purposes.

## How
- Implemented `extractWordsFormed` to collect main and cross-check words based on placement axes.
- Created `getWordAt` helper to scan board sequences while handling backtracking.
- Used a `Set` to ensure the resulting list of words is deduplicated and contains only valid sequences (length >= 2).
- Normalized all output to uppercase strings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changed Components

- **`party/lib/wordExtraction.ts`** (new file)
  - `extractWordsFormed(placements, board, newTiles)`
    - Validates inputs (returns `[]` for empty/invalid inputs)
    - Validates `placements.length === newTiles.length` (otherwise returns `[]`)
    - Bounds-checks all `placements`; rejects the entire operation if any placement is out of bounds (returns `[]`)
    - Clones the provided `board`, applies `newTiles` at `placements` to avoid mutating the original state
    - Requires the move to be strictly **horizontal** (all same `row`) or strictly **vertical** (all same `col`); otherwise returns `[]`
    - Reconstructs the **primary word** along the placement axis and adds it only if `word.length >= 2`
    - For each placed tile, reconstructs the **perpendicular/cross-check word(s)** in the opposite axis direction and adds them only if `word.length >= 2`
    - Uses a `Set` to deduplicate extracted words
    - Returns extracted words as **uppercase** strings
  - `getWordAt(board, row, col, dx, dy)` (local helper)
    - Backtracks from `(row, col)` along `(dx, dy)` to the earliest contiguous non-`null` tile
    - Iterates forward along `(dx, dy)` concatenating each tile’s `.letter` until reaching a `null` cell or the board boundary

## Intent

- Enable word extraction for **scoring** and **move validation** based on new tile placements
- Extract the **main word** (along the placement axis) and **cross-check words** (perpendicular to the placement axis)
- Reject invalid move shapes (non-horizontal/vertical), invalid placement input, and words shorter than 2 letters
- Prevent partial/invalid updates via whole-operation rejection on any bad placement; avoid mutating the original board
- Return consistent, deduplicated **uppercase** word outputs
<!-- end of auto-generated comment: release notes by coderabbit.ai -->