### PR TITLE
Add word validation and error reporting to turn submission

### DIFF
--- a/party/lib/gameState.ts
+++ b/party/lib/gameState.ts
@@ -148,6 +148,12 @@ export class GameState {
     }
 
     const words = extractWordsFormed(validatedPlacements, this.board, newTiles)
+    if (words.length === 0) {
+      return {
+        success: false,
+        error: { valid: false, error: "INVALID_WORD", invalidWords: [] },
+      }
+    }
     const invalidWords = words.filter((word) => !isValidWithBlank(word))
 
     if (invalidWords.length > 0) {

--- a/party/lib/gameState.ts
+++ b/party/lib/gameState.ts
@@ -2,7 +2,12 @@ import { BOARD_SIZE, MAX_PLAYERS, MIN_PLAYERS, RACK_SIZE } from "../constants"
 import { buildBag, drawTiles, refillRack, shuffleBag } from "./bag"
 import { isPlacement, type Player, type Tile } from "./types"
 import { advanceToNextConnectedPlayer, findFirstConnectedPlayer } from "./turns"
-import { SubmitErrorCode, validatePlacements } from "./validation"
+import { extractWordsFormed } from "./wordExtraction"
+import {
+  isValidWithBlank,
+  validatePlacements,
+  type ValidationError,
+} from "./validation"
 
 export interface PlayerConnectResult {
   isNewPlayer: boolean
@@ -15,7 +20,7 @@ export interface ToggleReadyResult {
 
 export type SubmitTurnResult =
   | { success: true; turnScore: number }
-  | { success: false; error: SubmitErrorCode }
+  | { success: false; error: ValidationError }
 
 export interface HandleReconnectResult {
   gameOver: boolean
@@ -111,9 +116,26 @@ export class GameState {
       ? placements.filter(isPlacement)
       : []
 
-    const result = validatePlacements(validatedPlacements, this.board)
-    if (!result.valid) {
-      return { success: false, error: result.error }
+    // Validate geometry and connectivity before modifying any game state
+    // to ensure an "atomic" operation—if anything fails, the board remains unchanged.
+    const geomResult = validatePlacements(validatedPlacements, this.board)
+    if (!geomResult.valid) {
+      return { success: false, error: geomResult }
+    }
+
+    // Verify all newly formed words against the dictionary.
+    // Validation must run before state update to reject illegal moves.
+    const newTiles = validatedPlacements.map(
+      ({ rackIndex }) => player.rack[rackIndex]
+    )
+    const words = extractWordsFormed(validatedPlacements, this.board, newTiles)
+    const invalidWords = words.filter((word) => !isValidWithBlank(word))
+
+    if (invalidWords.length > 0) {
+      return {
+        success: false,
+        error: { valid: false, error: "INVALID_WORD", invalidWords },
+      }
     }
 
     // Validate rackIndex bounds and uniqueness

--- a/party/lib/gameState.ts
+++ b/party/lib/gameState.ts
@@ -128,15 +128,6 @@ export class GameState {
     const newTiles = validatedPlacements.map(
       ({ rackIndex }) => player.rack[rackIndex]
     )
-    const words = extractWordsFormed(validatedPlacements, this.board, newTiles)
-    const invalidWords = words.filter((word) => !isValidWithBlank(word))
-
-    if (invalidWords.length > 0) {
-      return {
-        success: false,
-        error: { valid: false, error: "INVALID_WORD", invalidWords },
-      }
-    }
 
     // Validate rackIndex bounds and uniqueness
     const rackIndices = new Set<number>()
@@ -154,6 +145,16 @@ export class GameState {
         }
       }
       rackIndices.add(rackIndex)
+    }
+
+    const words = extractWordsFormed(validatedPlacements, this.board, newTiles)
+    const invalidWords = words.filter((word) => !isValidWithBlank(word))
+
+    if (invalidWords.length > 0) {
+      return {
+        success: false,
+        error: { valid: false, error: "INVALID_WORD", invalidWords },
+      }
     }
 
     for (const { row, col, rackIndex } of validatedPlacements) {

--- a/party/lib/gameState.ts
+++ b/party/lib/gameState.ts
@@ -142,10 +142,16 @@ export class GameState {
     const rackIndices = new Set<number>()
     for (const { rackIndex } of validatedPlacements) {
       if (rackIndex < 0 || rackIndex >= player.rack.length) {
-        return { success: false, error: "OUT_OF_BOUNDS" }
+        return {
+          success: false,
+          error: { valid: false, error: "OUT_OF_BOUNDS" },
+        }
       }
       if (rackIndices.has(rackIndex)) {
-        return { success: false, error: "DUPLICATE_COORDINATE" }
+        return {
+          success: false,
+          error: { valid: false, error: "DUPLICATE_COORDINATE" },
+        }
       }
       rackIndices.add(rackIndex)
     }

--- a/party/lib/messages.ts
+++ b/party/lib/messages.ts
@@ -1,6 +1,6 @@
 import type * as Party from "partykit/server"
 import type { PublicPlayer, Tile } from "./types"
-import type { SubmitErrorCode } from "./validation"
+import type { ValidationError } from "./validation"
 
 export function broadcastRoomState(room: Party.Room, players: PublicPlayer[]) {
   room.broadcast(JSON.stringify({ type: "ROOM_STATE", players }))
@@ -57,9 +57,9 @@ export function broadcastBoardState(
 
 export function sendSubmitError(
   conn: Party.Connection,
-  error: SubmitErrorCode
+  error: ValidationError
 ) {
-  conn.send(JSON.stringify({ type: "SUBMIT_ERROR", error }))
+  conn.send(JSON.stringify({ type: "SUBMIT_ERROR", ...error }))
 }
 
 export function broadcastGameOver(

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -20,6 +20,9 @@ export type ServerMessage =
         | "NOT_IN_LINE"
         | "GAP_NOT_FILLED"
         | "NOT_CONNECTED"
+        | "OUT_OF_BOUNDS"
+        | "CELL_OCCUPIED"
+        | "DUPLICATE_COORDINATE"
         | "INVALID_WORD"
       invalidWords?: string[]
     }

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -15,6 +15,7 @@ export type ServerMessage =
   | { type: "BOARD_STATE"; board: Record<string, TileType> }
   | {
       type: "SUBMIT_ERROR"
+      valid: false
       error:
         | "NO_TILES"
         | "NOT_IN_LINE"


### PR DESCRIPTION
## What
Integrated word extraction and dictionary validation into the turn submission flow.

## Why
To ensure moves are validated against the dictionary and to maintain atomic state updates, preventing board changes on invalid turns.

## How
- Refactored `submitTurn` in `party/lib/gameState.ts` to perform geometry and word validation using `extractWordsFormed` and `isValidWithBlank` prior to any state mutation.
- Updated `sendSubmitError` in `party/lib/messages.ts` to support broadcasting the full `ValidationError` object, including `invalidWords`.
- Updated `SubmitTurnResult` in `party/lib/gameState.ts` to return `ValidationError` instead of `SubmitErrorCode`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changed Components and Intent

- **party/lib/gameState.ts**
  - `SubmitTurnResult` type: updated failure branch error from `SubmitErrorCode` to `ValidationError` for richer error details
  - `GameState.submitTurn()` refactor: made turn submission validation atomic (board/rack/bag mutations occur only after all checks pass)
    - Geometry/connectivity validation via `validatePlacements`
    - Rack placement validation (bounds + duplicate coordinate detection)
    - Word extraction via `extractWordsFormed`
    - Dictionary validation via `isValidWithBlank`, returning `ValidationError` including `invalidWords` (including empty list when no words are formed)
- **party/lib/messages.ts**
  - `sendSubmitError()` updated to accept `ValidationError` instead of `SubmitErrorCode`
  - Wire payload change for `SUBMIT_ERROR`: now spreads validation error fields directly into the message (`{ type: "SUBMIT_ERROR", ...error }`) so clients can access `invalidWords`
- **src/types/messages.ts**
  - `ServerMessage["SUBMIT_ERROR"]` updated to extend the `error` string-literal union with:
    - `"OUT_OF_BOUNDS"`
    - `"CELL_OCCUPIED"`
    - `"DUPLICATE_COORDINATE"`
    - (alongside existing `"INVALID_WORD"`)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->