### PR TITLE
Track last error state in game session

### DIFF
--- a/src/hooks/game/useGameSession.ts
+++ b/src/hooks/game/useGameSession.ts
@@ -23,6 +23,7 @@ export function useGameSession(roomId: string) {
     winnerIds: string[]
     scores: Record<string, number>
   } | null>(null)
+  const [lastError, setLastError] = useState<ServerMessage | null>(null)
 
   const socket = usePartySocket({
     host:
@@ -65,6 +66,7 @@ export function useGameSession(roomId: string) {
             )
 
             toast.error(title, { description })
+            setLastError(msg)
             break
           }
           case "GAME_OVER":
@@ -108,5 +110,6 @@ export function useGameSession(roomId: string) {
     send,
     scores,
     gameOver,
+    lastError,
   }
 }

--- a/src/pages/Game.tsx
+++ b/src/pages/Game.tsx
@@ -36,6 +36,7 @@ function GameSessionView({ roomId }: { roomId: string }) {
     send,
     scores,
     gameOver,
+    lastError,
   } = useGameSession(roomId)
   const {
     rack,
@@ -59,6 +60,12 @@ function GameSessionView({ roomId }: { roomId: string }) {
       activationConstraint: { distance: 10 },
     })
   )
+
+  useEffect(() => {
+    if (lastError?.type === "SUBMIT_ERROR") {
+      isSubmittingRef.current = false
+    }
+  }, [lastError])
 
   useEffect(() => {
     if (isSubmittingRef.current) {


### PR DESCRIPTION
## What
Prevent the board from clearing when a turn submission is rejected.

## Why
Users need to be able to edit and resubmit their moves after receiving an invalid word error instead of starting over.

## How
- Added `lastError` state to `useGameSession` to track `SUBMIT_ERROR` events.
- Updated `Game` component to reset `isSubmittingRef` when `lastError` of type `SUBMIT_ERROR` is detected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- `src/hooks/game/useGameSession.ts`: Added `lastError` state to store the most recent `SUBMIT_ERROR` server message and exposed it from the hook so consumers can react to failed submissions.
- `src/pages/Game.tsx`: Consumes `lastError` from `useGameSession` and resets `isSubmittingRef` when a `SUBMIT_ERROR` is detected, letting players edit and resubmit after an invalid move without clearing the board.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->